### PR TITLE
Revisão de acessos

### DIFF
--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -11,7 +11,6 @@ class CommunitiesController < ApplicationController
 
   def index
     skip_authorization
-    skip_policy_scope
 
     if current_user
       render json: current_user.communities

--- a/app/controllers/concerns/controller_helper.rb
+++ b/app/controllers/concerns/controller_helper.rb
@@ -1,0 +1,13 @@
+module ControllerHelper
+  def render_404
+    skip_authorization
+
+    render nothing: true, status: 404
+  end
+
+  def render_status status, messages
+    skip_authorization
+
+    render json: messages, status: status
+  end
+end

--- a/app/controllers/mobilizations/blocks_controller.rb
+++ b/app/controllers/mobilizations/blocks_controller.rb
@@ -3,29 +3,43 @@ class Mobilizations::BlocksController < ApplicationController
   after_action :verify_authorized, except: %i[index]
   after_action :verify_policy_scoped, only: %i[index]
 
+  include ControllerHelper
+
   def index
     render json: policy_scope(Block).where(mobilization_id: params[:mobilization_id]).order(:position)
   end
 
   def create
-    @block = Block.new(block_params.merge(mobilization_id: params[:mobilization_id]))
-    authorize @block
-    @block.save!
-    render json: @block , serializer: BlockSerializer::CompleteBlockSerializer
+    if Mobilization.find_by({id: params[:mobilization_id]})
+      @block = Block.new(block_params.merge(mobilization_id: params[:mobilization_id]))
+      authorize @block
+      @block.save!
+      render json: @block , serializer: BlockSerializer::CompleteBlockSerializer
+    else
+      render_status 400, ['Mobilization does not exist']
+    end
   end
 
   def update
     @block = Block.where(mobilization_id: params[:mobilization_id], id: params[:id]).first
-    authorize @block
-    @block.update!(block_params)
-    render json: @block
+    if @block
+      authorize @block
+      @block.update!(block_params)
+      render json: @block
+    else
+      render_404
+    end
   end
 
   def destroy
     @block = Block.where(mobilization_id: params[:mobilization_id], id: params[:id]).first
-    authorize @block
-    @block.destroy!
-    render json: @block
+    if @block
+      authorize @block
+      @block.destroy!
+      render json: @block
+    else
+      render_404
+    end
   end
 
   private

--- a/app/controllers/mobilizations_controller.rb
+++ b/app/controllers/mobilizations_controller.rb
@@ -1,4 +1,6 @@
 class MobilizationsController < ApplicationController
+  include ControllerHelper
+
   respond_to :json
   after_action :verify_authorized, except: %i[index published]
   after_action :verify_policy_scoped, only: %i[index published]
@@ -37,6 +39,9 @@ class MobilizationsController < ApplicationController
   end
 
   def create
+    community = Community.find params[:mobilization][:community_id]
+    authorize community, :update?
+
     @mobilization = Mobilization.new(mobilization_params)
     @mobilization.user = current_user
     authorize @mobilization
@@ -74,7 +79,7 @@ class MobilizationsController < ApplicationController
         end
         render json: @mobilization
       else
-        return404
+        render_404
       end
     else
       authorize @mobilization

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -1,6 +1,7 @@
 class Block < ActiveRecord::Base
   validates :mobilization_id, :position, presence: true
   belongs_to :mobilization
+  has_one :community, through: :mobilization
   has_many :widgets
   accepts_nested_attributes_for :widgets
 

--- a/app/policies/block_policy.rb
+++ b/app/policies/block_policy.rb
@@ -1,16 +1,24 @@
 class BlockPolicy < ApplicationPolicy
   def permitted_attributes
-    if create?
+    # if create?
       [:position, :bg_class, :bg_image, :hidden, :name, :menu_hidden,
         widgets_attributes: [:kind, :sm_size, :md_size, :lg_size]]
-    else
-      []
-    end
+    # else
+    #   []
+    # end
+  end
+
+  def create?
+    is_owned_by?(user)
+  end
+
+  def destroy?
+    is_owned_by?(user)
   end
 
   private
 
   def is_owned_by?(user)
-    user.present? && record.mobilization.user == user
+    user.present? && ( user.admin? or record.community.users.include? user or record.mobilization.user == user )
   end
 end

--- a/app/policies/community_policy.rb
+++ b/app/policies/community_policy.rb
@@ -1,4 +1,25 @@
 class CommunityPolicy < ApplicationPolicy
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      if user 
+        if user.admin
+          scope.all
+        else
+          scope.where("id in (select cu.community_id from community_users cu where cu.user_id = #{@user.id})")
+        end
+      else
+        scope.where("0 = 1")
+      end
+    end
+  end
+
   def permitted_attributes
     [:name, :city, :pagarme, :transfer_day, :transfer_enabled, :image, :description, :mailchimp_api_key, :mailchimp_list_id, :mailchimp_group_id, :facebook_app_id, :fb_link, :twitter_link, :subscription_dead_days_interval, :subscription_retry_interval, :email_template_from]
   end
@@ -24,7 +45,6 @@ class CommunityPolicy < ApplicationPolicy
   end
 
 private
-
   def is_owned_by?(user)
     user.present? && record.users.include?(user)
   end

--- a/app/policies/community_policy.rb
+++ b/app/policies/community_policy.rb
@@ -12,7 +12,7 @@ class CommunityPolicy < ApplicationPolicy
         if user.admin
           scope.all
         else
-          scope.where("id in (select cu.community_id from community_users cu where cu.user_id = #{@user.id})")
+          scope.where("id in (select cu.community_id from community_users cu where cu.user_id = ?)", @user.id)
         end
       else
         scope.where("0 = 1")

--- a/app/policies/mobilization_policy.rb
+++ b/app/policies/mobilization_policy.rb
@@ -25,4 +25,11 @@ class MobilizationPolicy < ApplicationPolicy
   def authenticated?
     user.present?
   end
+
+  private
+
+  def is_owned_by?(user)
+    user.present? and (record.user == user or record.community.users.include? user)
+  end
+
 end

--- a/app/policies/widget_policy.rb
+++ b/app/policies/widget_policy.rb
@@ -65,6 +65,6 @@ class WidgetPolicy < ApplicationPolicy
   private
 
   def is_owned_by?(user)
-    user.present? && record.mobilization.user == user
+    user.present? and (record.mobilization.user == user or record.community.users.include? user)
   end
 end

--- a/spec/controllers/mobilizations/blocks_controller_spec.rb
+++ b/spec/controllers/mobilizations/blocks_controller_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Mobilizations::BlocksController, type: :controller do
+  let(:user) { User.make! }
+  let(:user_admin) { User.make! admin: true }
+
   before do
-    @user = User.make!
-    stub_current_user(@user)
+    stub_current_user(user)
   end
 
   describe "GET #index" do
@@ -21,73 +23,225 @@ RSpec.describe Mobilizations::BlocksController, type: :controller do
   end
 
   describe "POST #create" do
-    it "should create with JSON format and empty params" do
-      mobilization = Mobilization.make!
-      expect(mobilization.blocks.count).to eq(0)
-      post :create, mobilization_id: mobilization.id, format: :json
+    context 'User in community list' do
+      let(:mobilization) { Mobilization.make! }
+      before { CommunityUser.create! user_id: user.id, community_id: mobilization.community.id, role: 1 }
+      
+      it "should create with JSON format and empty params" do
+        mobilization = Mobilization.make!
+        expect(mobilization.blocks.count).to eq(0)
+        post :create, mobilization_id: mobilization.id, format: :json
 
-      expect(mobilization.blocks.count).to eq(1)
-      expect(response.body).to include(BlockSerializer::CompleteBlockSerializer.new(mobilization.blocks.first).to_json)
+        expect(mobilization.blocks.count).to eq(1)
+        expect(response.body).to include(BlockSerializer::CompleteBlockSerializer.new(mobilization.blocks.first).to_json)
+      end
+
+      it "should create with JSON format and parameters" do
+        mobilization = Mobilization.make!
+        expect(mobilization.blocks.count).to eq(0)
+        post :create, mobilization_id: mobilization.id, format: :json, block: { position: 12345, bg_class: 'bg-yellow', bg_image: 'foobar.jpg', hidden: true }
+
+        expect(mobilization.blocks.count).to eq(1)
+        block = mobilization.blocks.first
+        expect(response.body).to include(BlockSerializer::CompleteBlockSerializer.new(block).to_json)
+        expect(block.position).to eq(12345)
+        expect(block.bg_class).to eq('bg-yellow')
+        expect(block.bg_image).to eq('foobar.jpg')
+        expect(block.hidden).to eq(true)
+      end
+
+      it "should create nested widgets" do
+        mobilization = Mobilization.make!
+        expect(mobilization.blocks.count).to eq(0)
+        post :create, mobilization_id: mobilization.id, format: :json, block: { widgets_attributes: [{kind: 'content', sm_size: 8, md_size: 6, lg_size: 6}, {kind: 'weather', sm_size: 12, md_size: 12, lg_size: 4}] }
+        expect(mobilization.blocks.count).to eq(1)
+        block = mobilization.blocks.first
+        expect(response.body).to include(BlockSerializer::CompleteBlockSerializer.new(block).to_json)
+        expect(block.widgets.count).to eq(2)
+        widget1 = block.widgets[0]
+        widget2 = block.widgets[1]
+        expect(widget1.kind).to eq('content')
+        expect(widget1.sm_size).to eq(8)
+        expect(widget1.md_size).to eq(6)
+        expect(widget1.lg_size).to eq(6)
+        expect(widget2.kind).to eq('weather')
+        expect(widget2.sm_size).to eq(12)
+        expect(widget2.md_size).to eq(12)
+        expect(widget2.lg_size).to eq(4)
+      end
+
+      context 'mobilization does not exists' do
+        before do
+          post :create, mobilization_id: 0, format: :json
+        end
+
+        it 'should return a 400 status' do
+          expect(response.status).to be 400
+        end
+
+        it 'should return an advice message' do
+          expect(response.body).to include('Mobilization')
+        end
+      end
     end
 
-    it "should create with JSON format and parameters" do
-      mobilization = Mobilization.make!
-      expect(mobilization.blocks.count).to eq(0)
-      post :create, mobilization_id: mobilization.id, format: :json, block: { position: 12345, bg_class: 'bg-yellow', bg_image: 'foobar.jpg', hidden: true }
 
-      expect(mobilization.blocks.count).to eq(1)
-      block = mobilization.blocks.first
-      expect(response.body).to include(BlockSerializer::CompleteBlockSerializer.new(block).to_json)
-      expect(block.position).to eq(12345)
-      expect(block.bg_class).to eq('bg-yellow')
-      expect(block.bg_image).to eq('foobar.jpg')
-      expect(block.hidden).to eq(true)
+    context 'User admin' do
+      let(:mobilization) { Mobilization.make! }
+      before { stub_current_user(user_admin) }
+
+      it "should create with JSON format and empty params" do
+        expect(mobilization.blocks.count).to eq(0)
+
+        post :create, mobilization_id: mobilization.id, format: :json
+
+        expect(mobilization.blocks.count).to eq(1)
+        expect(response.body).to include(mobilization.blocks.first.to_json)
+      end
     end
 
-    it "should create nested widgets" do
-      mobilization = Mobilization.make!
-      expect(mobilization.blocks.count).to eq(0)
-      post :create, mobilization_id: mobilization.id, format: :json, block: { widgets_attributes: [{kind: 'content', sm_size: 8, md_size: 6, lg_size: 6}, {kind: 'weather', sm_size: 12, md_size: 12, lg_size: 4}] }
-      expect(mobilization.blocks.count).to eq(1)
-      block = mobilization.blocks.first
-      expect(response.body).to include(BlockSerializer::CompleteBlockSerializer.new(block).to_json)
-      expect(block.widgets.count).to eq(2)
-      widget1 = block.widgets[0]
-      widget2 = block.widgets[1]
-      expect(widget1.kind).to eq('content')
-      expect(widget1.sm_size).to eq(8)
-      expect(widget1.md_size).to eq(6)
-      expect(widget1.lg_size).to eq(6)
-      expect(widget2.kind).to eq('weather')
-      expect(widget2.sm_size).to eq(12)
-      expect(widget2.md_size).to eq(12)
-      expect(widget2.lg_size).to eq(4)
+    context 'User not from community' do
+      let(:mobilization) { Mobilization.make! }
+      before { stub_current_user(User.make) }
+
+      it "should return a 401" do
+        expect(mobilization.blocks.count).to eq(0)
+
+        post :create, mobilization_id: mobilization.id, format: :json
+
+        expect(response.status).to be 401
+      end
     end
   end
 
   describe "PUT #update" do
-    it "should update with JSON format" do
-      mobilization = Mobilization.make! user: @user
-      block = Block.make! mobilization: mobilization, bg_class: 'bg-white', position: 123, hidden: false
-      put :update, mobilization_id: mobilization.id, id: block.id, format: :json, block: { position: 321, bg_class: 'bg-yellow', bg_image: 'foobar.jpg',  hidden: true }
-      block.reload
-      expect(block.position).to eq(321)
-      expect(block.bg_class).to eq('bg-yellow')
-      expect(block.bg_image).to eq('foobar.jpg')
-      expect(block.hidden).to eq(true)
-      expect(response.body).to include(block.to_json)
+    let(:mobilization) { Mobilization.make! }
+
+    context 'User in community\'s list' do
+      let(:block) { Block.make! mobilization: mobilization, bg_class: 'bg-white', position: 123, hidden: false }
+
+      before do
+        CommunityUser.create! user_id: user.id, community_id: mobilization.community.id, role: 1
+
+        put :update, mobilization_id: mobilization.id, id: block.id, format: :json, block: { position: 321, bg_class: 'bg-yellow', bg_image: 'foobar.jpg',  hidden: true }
+      end
+
+      it 'should return a 200 status' do
+        expect(response.status).to be 200
+      end
+      
+      it "should update with JSON format" do
+        block.reload
+        expect(block.position).to eq(321)
+        expect(block.bg_class).to eq('bg-yellow')
+        expect(block.bg_image).to eq('foobar.jpg')
+        expect(block.hidden).to eq(true)
+        expect(response.body).to include(block.to_json)
+      end
+    end
+
+    context 'User not in community\'s list' do
+      let(:block) { Block.make! mobilization: mobilization, bg_class: 'bg-white', position: 123, hidden: false }
+
+      before do
+        put :update, mobilization_id: mobilization.id, id: block.id, format: :json, block: { position: 321, bg_class: 'bg-yellow', bg_image: 'foobar.jpg',  hidden: true }
+      end
+
+      it 'should return a 401 status' do
+        expect(response.status).to be 401
+      end
+    end
+
+    context 'User is an admin' do
+      let(:block) { Block.make! mobilization: mobilization, bg_class: 'bg-white', position: 123, hidden: false }
+
+      before do
+        stub_current_user(user_admin)
+
+        put :update, mobilization_id: mobilization.id, id: block.id, format: :json, block: { position: 321, bg_class: 'bg-yellow', bg_image: 'foobar.jpg',  hidden: true }
+      end
+
+      it 'should return a 200 status' do
+        expect(response.status).to be 200
+      end
+    end
+
+    context 'block not exists' do
+      it 'should return status 404' do
+        put :update, mobilization_id: mobilization.id, id: 0, format: :json, block: { position: 321, bg_class: 'bg-yellow', bg_image: 'foobar.jpg',  hidden: true }
+        expect(response.status).to be 404
+      end
     end
   end
+
 
   describe "DELETE #destroy" do
-    it "should destroy with JSON format" do
-      mobilization = Mobilization.make! user: @user
-      block = Block.make! mobilization: mobilization, bg_class: 'bg-white', position: 123, hidden: false
-      expect(mobilization.blocks.count).to eq(1)
-      delete :destroy, mobilization_id: mobilization.id, id: block.id, format: :json
-      expect(mobilization.blocks.count).to eq(0)
-      expect(response.body).to include(block.to_json)
+    let(:mobilization) { Mobilization.make! }
+
+    before do 
+      @block = Block.make! mobilization: mobilization, bg_class: 'bg-white', position: 123, hidden: false
+      @count = mobilization.blocks.count 
+    end
+
+    context 'user in community\'s list' do
+      before do
+        CommunityUser.create! user_id: user.id, community_id: mobilization.community.id, role: 1
+
+        delete :destroy, mobilization_id: mobilization.id, id: @block.id, format: :json
+      end
+
+      it 'should return status 200' do
+        expect(response.status).to be 200
+      end
+      
+      it "should destroy with JSON format" do
+        expect(mobilization.blocks.count).to eq(@count - 1)
+        expect(response.body).to include(@block.to_json)
+      end
+    end
+
+    context 'user is mobilization\'s creator' do
+      before do
+        mobilization.update_attributes user_id: user.id
+        delete :destroy, mobilization_id: mobilization.id, id: @block.id, format: :json
+      end
+
+      it 'should return status 200' do
+        expect(response.status).to be 200
+      end
+    end
+
+    context 'user not in community\'s list' do
+      before do
+        delete :destroy, mobilization_id: mobilization.id, id: @block.id, format: :json
+      end
+
+      it 'should return status 401' do
+        expect(response.status).to be 401
+      end
+    end
+
+    context 'user is an admin' do
+      before do
+        stub_current_user user_admin
+        delete :destroy, mobilization_id: mobilization.id, id: @block.id, format: :json
+      end
+
+      it 'should return status 200' do
+        expect(response.status).to be 200
+      end
+      
+      it "should destroy with JSON format" do
+        expect(mobilization.blocks.count).to eq(@count - 1)
+        expect(response.body).to include(@block.to_json)
+      end
+    end
+
+    context 'block not exists' do
+      it 'should return status 404' do
+        delete :destroy, mobilization_id: mobilization.id, id: 0, format: :json
+        expect(response.status).to be 404
+      end
     end
   end
-
 end

--- a/spec/controllers/mobilizations/widgets_controller_spec.rb
+++ b/spec/controllers/mobilizations/widgets_controller_spec.rb
@@ -71,6 +71,19 @@ RSpec.describe Mobilizations::WidgetsController, type: :controller do
         expect(response).to be_unauthorized
       end
 
+      it "should return 404 widget does not exist" do
+        stub_current_user(User.make!)
+        put :update,  { mobilization_id: @widget1.block.mobilization_id, id: 0,
+            widget: {
+              settings: {
+                content: "Widget new content"
+              }
+            }
+          }
+
+        expect(response).to be_not_found
+      end
+
       context "with huge emails(500) for target pressure" do
         before do
           stub_current_user(@admin)

--- a/spec/controllers/mobilizations/widgets_controller_spec.rb
+++ b/spec/controllers/mobilizations/widgets_controller_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe Mobilizations::WidgetsController, type: :controller do
     end
   end
 
+
+
   describe "PUT #update" do
     context 'with valid payload' do
       it "should update widget when current user is admin" do
@@ -37,6 +39,16 @@ RSpec.describe Mobilizations::WidgetsController, type: :controller do
 
       it "should update widget when current user is the mobilization's owner" do
         stub_current_user(@widget1.mobilization.user)
+
+        put :update, update_widget_1_params
+
+        expect(response.body).to include("Widget new content")
+      end
+
+      it "should update widget when current user is part of the community" do
+        stub_current_user(@user)
+        CommunityUser.create! user_id: @user.id, community_id: @widget1.community.id, role:1
+
         put :update, update_widget_1_params
 
         expect(response.body).to include("Widget new content")
@@ -52,7 +64,7 @@ RSpec.describe Mobilizations::WidgetsController, type: :controller do
         expect(saved.settings['finish_message_background']).to eq('finish_message_background string')
       end
 
-      it "should return 401 if user is not an admin or mobilization's owner" do
+      it "should return 401 if user is not an admin, mobilization's owner or in the mobilization's users list" do
         stub_current_user(User.make!)
         put :update, update_widget_1_params
 

--- a/spec/controllers/mobilizations_controller_spec.rb
+++ b/spec/controllers/mobilizations_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe MobilizationsController, type: :controller do
 
   before { stub_current_user(user1) }
 
+
   describe "GET #index" do
     let!(:mob1) { Mobilization.make! user: user1, custom_domain: "foobar", slug: "1-foo" }
     let!(:mob2) { Mobilization.make! user: user2 }
@@ -57,6 +58,7 @@ RSpec.describe MobilizationsController, type: :controller do
     end
   end
 
+<<<<<<< HEAD
   describe 'PATCH #update' do
     context 'update an existing Mobilization' do
       subject {
@@ -85,19 +87,35 @@ RSpec.describe MobilizationsController, type: :controller do
   describe 'PUT #update' do
     let(:template) { TemplateMobilization.make! }
     let(:mobilization) { Mobilization.make! user: user1, slug: nil }
+=======
+
+
+  describe 'PATCH #update' do
+    let(:template) { TemplateMobilization.make! }
+    let(:mobilization) { Mobilization.make!  user: user2 }
+>>>>>>> [#136390875] Mobilization revised
     let(:saved_mobilization) { Mobilization.find mobilization.id }
+
 
     context "update an existing Mobilization from an existing template" do
       let(:template_block_1) { TemplateBlock.make! template_mobilization:template }
-      let(:tempalte_widget_1_1) { TemplateWidget.make! template_block:template_block_1 }
+      let(:template_widget_1_1) { TemplateWidget.make! template_block:template_block_1 }
       let(:tempalte_widget_1_2) { TemplateWidget.make! template_block:template_block_1 }
       let(:template_block_2) { TemplateBlock.make! template_mobilization:template }
       let(:tempalte_widget_2_1) { TemplateWidget.make! template_block:template_block_2 }
       let(:tempalte_widget_2_2) { TemplateWidget.make! template_block:template_block_2 }
 
       before do
+        stub_current_user user2
         @template_blocks  = [template_block_1, template_block_2]
+<<<<<<< HEAD
         @template_widgets = [tempalte_widget_1_1, tempalte_widget_1_2, tempalte_widget_2_1, tempalte_widget_2_2]
+=======
+        @template_widgets = [template_widget_1_1, tempalte_widget_1_2, tempalte_widget_2_1, tempalte_widget_2_2]
+        stub_request(:delete, "https://api.heroku.com/apps//domains/mymobilization").
+          with(:headers => {'Accept'=>'application/vnd.heroku+json; version=3', 'Authorization'=>'Bearer ', 'Host'=>'api.heroku.com:443', 'User-Agent'=>'excon/0.45.4'}).
+          to_return(:status => 200, :body => "", :headers => {})
+>>>>>>> [#136390875] Mobilization revised
 
         put :update, { mobilization: { template_mobilization_id: template.id } , id: mobilization.id }
       end
@@ -143,10 +161,162 @@ RSpec.describe MobilizationsController, type: :controller do
       end
     end
 
+<<<<<<< HEAD
     context "update from an inexisting template" do
       before { put :update, { mobilization: { template_mobilization_id: 0 }, id: mobilization.id } }
+=======
+    context 'Mobilization' do    
+      context 'user not in community\'s list' do
+        before do
+          patch :update, {format: :json, mobilization: {name: 'super-hiper-marevelous mobilization'}, id: mobilization.id}
+        end
 
-      it { should respond_with 404 }
+        it 'should return an 401' do
+          expect(response).to be_unauthorized
+        end
+      end
+
+      context 'user in community\'s list' do
+        before do
+          CommunityUser.create! user_id: user1.id, community_id: mobilization.community.id, role: 1
+          patch :update, {format: :json, mobilization: {name: 'super-hiper-marevelous mobilization'}, id: mobilization.id}
+        end
+
+        it 'should change data in database' do
+          expect((Mobilization.find mobilization.id).name).to eq('super-hiper-marevelous mobilization')
+        end
+
+        it 'should return an 200' do
+          expect(response.status).to be 200
+        end
+      end
+
+      context 'user is admin' do
+        before do
+          user1.update_attributes admin: true
+          patch :update, {format: :json, mobilization: {name: 'super-hiper-marevelous mobilization'}, id: mobilization.id}
+        end
+>>>>>>> [#136390875] Mobilization revised
+
+        it 'should change data in database' do
+          expect((Mobilization.find mobilization.id).name).to eq('super-hiper-marevelous mobilization')
+        end
+
+        it 'should return an 200' do
+          expect(response.status).to be 200
+        end
+      end
+
+      context 'mobilization does not exist' do
+        it 'should return a 404 (not found) status' do
+          patch :update, {format: :json, mobilization: {name: 'super-hiper-marevelous mobilization'}, id: 0}
+
+          expect(response).to be_not_found
+        end
+      end
+  
+      context 'from Template' do
+        let(:template) { TemplateMobilization.make! }
+        let(:block) { TemplateBlock.make! template_mobilization:template }
+        
+        before do
+          TemplateWidget.make! template_block:block
+          
+          stub_request(:delete, "https://api.heroku.com/apps//domains/mymobilization").
+            with(:headers => {'Accept'=>'application/vnd.heroku+json; version=3', 'Authorization'=>'Bearer ', 'Host'=>'api.heroku.com:443', 'User-Agent'=>'excon/0.45.4'}).
+            to_return(:status => 200, :body => "", :headers => {})
+        end
+
+        context "admin user" do
+          before do
+            user1.update_attributes admin: true
+
+            put :update, { template_mobilization_id: template.id, id: mobilization.id }
+          end
+
+          it "should return a 200 status if created" do
+            expect(response.status).to eq(200)
+          end
+
+          it "should update data from a template" do
+            mob = Mobilization.find mobilization.id
+            expect(mob.header_font).to eq(template.header_font)
+          end
+
+          it "should not update name from a mobilization" do
+            mob = Mobilization.find mobilization.id
+            expect(mob.name).to eq(mobilization.name)
+          end
+
+          it "should not update goal from a mobilization" do
+            mob = Mobilization.find mobilization.id
+            expect(mob.goal).to eq(mobilization.goal)
+          end
+
+          it "should return the new data" do
+            expect(response.body).to include(template.header_font)
+          end
+
+          it 'should increment the uses_number for each use' do
+            newTemplate = TemplateMobilization.find template.id
+            expect(newTemplate.uses_number).to eq((template.uses_number||0) + 1)
+          end
+        end
+
+        context "user in community's list" do
+          before do
+            CommunityUser.create! community_id: mobilization.community.id, user_id: user1.id, role: 1
+
+            put :update, { template_mobilization_id: template.id, id: mobilization.id }
+          end
+
+          it "should return a 200 status if created" do
+            expect(response.status).to eq(200)
+          end
+
+          it "should update data from a template" do
+            mob = Mobilization.find mobilization.id
+            expect(mob.header_font).to eq(template.header_font)
+          end
+
+          it "should not update name from a mobilization" do
+            mob = Mobilization.find mobilization.id
+            expect(mob.name).to eq(mobilization.name)
+          end
+
+          it "should not update goal from a mobilization" do
+            mob = Mobilization.find mobilization.id
+            expect(mob.goal).to eq(mobilization.goal)
+          end
+
+          it "should return the new data" do
+            expect(response.body).to include(template.header_font)
+          end
+
+          it 'should increment the uses_number for each use' do
+            newTemplate = TemplateMobilization.find template.id
+            expect(newTemplate.uses_number).to eq((template.uses_number||0) + 1)
+          end
+        end
+
+        context "user in community's list" do
+          before do
+            put :update, { template_mobilization_id: template.id, id: mobilization.id }
+          end
+
+          it "should return a 401 status" do
+            expect(response).to be_unauthorized
+          end
+        end
+
+        context "update from an inexisting template" do
+          it "should return a 404 status" do
+            put :update, { template_mobilization_id: 0, id: mobilization.id }
+
+            expect(response.status).to eq(404)
+          end
+        end
+      end
     end
 
     context "fields changing validation" do
@@ -165,6 +335,7 @@ RSpec.describe MobilizationsController, type: :controller do
       it { expect(assigns(:mobilization).custom_domain).to eq('anewdomainfor.us')}
     end
   end
+<<<<<<< HEAD
 
 
   describe "POST #create" do
@@ -173,20 +344,77 @@ RSpec.describe MobilizationsController, type: :controller do
     context "single creation" do
       it "should create with JSON format" do
         expect(Mobilization.count).to eq(0)
+=======
 
+  describe "POST #create" do
+    let(:community){ Community.make! }
+>>>>>>> [#136390875] Mobilization revised
+
+    context "user not in comuunity's users list - single creation" do
+      before do
         post :create, format: :json, mobilization: {
           name: 'Foo',
           goal: 'Bar',
           community_id: community.id,
           tag_list: "luta, corrupção"
         }
+      end
+      
+      it 'should return a 401 status' do
+        expect(response).to be_unauthorized
+      end
+    end
 
+    context "user in comuunity's users list - single creation" do
+      before do
+        CommunityUser.create! user_id: user1.id, community_id: community.id, role: 1
+        @count = Mobilization.count
+
+<<<<<<< HEAD
         expect(Mobilization.count).to eq(1)
         expect(response.body).to include('tag_list')
         expect(response.body).to include('luta')
         expect(response.body).to include('corrupcao')
         expect(response.body).to include('Foo')
         expect(response.body).to include('Bar')
+=======
+        post :create, format: :json, mobilization: {
+          name: 'Foo',
+          goal: 'Bar',
+          community_id: community.id
+        }
+      end
+      
+      it "should create with JSON format" do    
+        expect(Mobilization.count).to eq(@count+1)
+        expect(response.body).to include(Mobilization.first.to_json)
+>>>>>>> [#136390875] Mobilization revised
+      end
+
+      it 'should return a 200 status' do
+        expect(response).to be_ok
+      end
+    end
+
+    context "user is admin - single creation" do
+      before do
+        user1.update_attributes admin: true
+        @count = Mobilization.count
+
+        post :create, format: :json, mobilization: {
+          name: 'Foo',
+          goal: 'Bar',
+          community_id: community.id
+        }
+      end
+      
+      it "should create with JSON format" do    
+        expect(Mobilization.count).to eq(@count+1)
+        expect(response.body).to include(Mobilization.first.to_json)
+      end
+
+      it 'should return a 200 status' do
+        expect(response).to be_ok
       end
     end
 

--- a/spec/controllers/mobilizations_controller_spec.rb
+++ b/spec/controllers/mobilizations_controller_spec.rb
@@ -386,6 +386,12 @@ RSpec.describe MobilizationsController, type: :controller do
       it 'should return a 200 status' do
         expect(response).to be_ok
       end
+
+      it "should return the values saved" do
+          expect(response.body).to include("\"name\":\"Foo\"")
+          expect(response.body).to include("\"goal\":\"Bar\"")
+          expect(response.body).to include("\"community_id\":#{community.id}")
+      end
     end
 
     context "user is admin - single creation" do
@@ -407,6 +413,12 @@ RSpec.describe MobilizationsController, type: :controller do
 
       it 'should return a 200 status' do
         expect(response).to be_ok
+      end
+
+      it "should return the values saved" do
+          expect(response.body).to include("\"name\":\"Foo\"")
+          expect(response.body).to include("\"goal\":\"Bar\"")
+          expect(response.body).to include("\"community_id\":#{community.id}")
       end
     end
 

--- a/spec/controllers/mobilizations_controller_spec.rb
+++ b/spec/controllers/mobilizations_controller_spec.rb
@@ -93,7 +93,6 @@ RSpec.describe MobilizationsController, type: :controller do
   describe 'PATCH #update' do
     let(:template) { TemplateMobilization.make! }
     let(:mobilization) { Mobilization.make!  user: user2 }
->>>>>>> [#136390875] Mobilization revised
     let(:saved_mobilization) { Mobilization.find mobilization.id }
 
 
@@ -108,14 +107,7 @@ RSpec.describe MobilizationsController, type: :controller do
       before do
         stub_current_user user2
         @template_blocks  = [template_block_1, template_block_2]
-<<<<<<< HEAD
         @template_widgets = [tempalte_widget_1_1, tempalte_widget_1_2, tempalte_widget_2_1, tempalte_widget_2_2]
-=======
-        @template_widgets = [template_widget_1_1, tempalte_widget_1_2, tempalte_widget_2_1, tempalte_widget_2_2]
-        stub_request(:delete, "https://api.heroku.com/apps//domains/mymobilization").
-          with(:headers => {'Accept'=>'application/vnd.heroku+json; version=3', 'Authorization'=>'Bearer ', 'Host'=>'api.heroku.com:443', 'User-Agent'=>'excon/0.45.4'}).
-          to_return(:status => 200, :body => "", :headers => {})
->>>>>>> [#136390875] Mobilization revised
 
         put :update, { mobilization: { template_mobilization_id: template.id } , id: mobilization.id }
       end

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -2,9 +2,14 @@ require 'rails_helper'
 
 RSpec.describe Block, type: :model do
   it { should belong_to :mobilization }
+
+  it { should have_one :community }
+  
   it { should have_many :widgets }
+  
   it { should validate_presence_of :mobilization_id }
   it { should validate_presence_of :position }
+  
   it { should accept_nested_attributes_for :widgets }
 
   describe "#set_position" do

--- a/spec/policies/block_policy_spec.rb
+++ b/spec/policies/block_policy_spec.rb
@@ -10,23 +10,46 @@ RSpec.describe BlockPolicy do
     it { should_not allows(:update) }
     it { should_not allows(:edit) }
     it { should_not allows(:destroy) }
+
     it "should have complete scope" do
       expect(subject.scope).to eq Block
     end
-    it "should return empty permitted attributes" do
-      expect(subject.permitted_attributes).to eq []
-    end
   end
 
-  context "for a non-owner user" do
-    subject { described_class.new(User.make!, Block.make!) }
+  context "for a user in community's list" do
+    let(:user) { User.make! }
+    let(:block) { Block.make! }
+    subject { described_class.new(user, block) }
+
+    before { CommunityUser.create! user_id: user.id, community_id: block.community.id, role: 1 }
+
     it { should allows(:index) }
     it { should allows(:show) }
     it { should allows(:create) }
     it { should allows(:new) }
-    it { should_not allows(:update) }
-    it { should_not allows(:edit) }
-    it { should_not allows(:destroy) }
+    it { should allows(:update) }
+    it { should allows(:edit) }
+    it { should allows(:destroy) }
+    it "should have complete scope" do
+      expect(subject.scope).to eq Block
+    end
+    it "should return permitted attributes" do
+      expect(subject.permitted_attributes).to eq [
+        :position, :bg_class, :bg_image, :hidden, :name, :menu_hidden,
+        widgets_attributes: [:kind, :sm_size, :md_size, :lg_size]
+      ]
+    end
+  end
+
+  context "for a admin user" do
+    subject { described_class.new((User.make! admin: true), Block.make!) }
+    it { should allows(:index) }
+    it { should allows(:show) }
+    it { should allows(:create) }
+    it { should allows(:new) }
+    it { should allows(:update) }
+    it { should allows(:edit) }
+    it { should allows(:destroy) }
     it "should have complete scope" do
       expect(subject.scope).to eq Block
     end

--- a/spec/policies/mobilization_policy_spec.rb
+++ b/spec/policies/mobilization_policy_spec.rb
@@ -50,6 +50,74 @@ RSpec.describe MobilizationPolicy do
     end
   end
 
+  context "for a user in community's list" do
+    let(:user) { User.make! }
+    let(:mobilization) { Mobilization.make! }
+    subject { described_class.new(user, mobilization) }
+    
+    before { CommunityUser.create! user_id: user.id, community_id: mobilization.community.id, role: 1 }
+
+    it { should allows(:index) }
+    it { should allows(:show) }
+    it { should allows(:create) }
+    it { should allows(:new) }
+    it { should allows(:update) }
+    it { should allows(:edit) }
+    it { should allows(:destroy) }
+    it "should have complete scope" do
+      expect(subject.scope).to eq Mobilization
+    end
+    it "should return permitted attributes" do
+      expect(subject.permitted_attributes).to eq [
+        :name,
+        :color_scheme,
+        :google_analytics_code,
+        :goal,
+        :facebook_share_title,
+        :facebook_share_description,
+        :facebook_share_image,
+        :twitter_share_text,
+        :header_font,
+        :body_font,
+        :custom_domain,
+        :slug,
+        :community_id
+      ]
+    end
+  end
+
+  context "for an admin" do
+    let(:user) { User.make! admin: true}
+    subject { described_class.new(user, Mobilization.make!) }
+    it { should allows(:index) }
+    it { should allows(:show) }
+    it { should allows(:create) }
+    it { should allows(:new) }
+    it { should allows(:update) }
+    it { should allows(:edit) }
+    it { should allows(:destroy) }
+    it "should have complete scope" do
+      expect(subject.scope).to eq Mobilization
+    end
+    it "should return permitted attributes" do
+      expect(subject.permitted_attributes).to eq [
+        :name,
+        :color_scheme,
+        :google_analytics_code,
+        :goal,
+        :facebook_share_title,
+        :facebook_share_description,
+        :facebook_share_image,
+        :twitter_share_text,
+        :header_font,
+        :body_font,
+        :custom_domain,
+        :slug,
+        :community_id
+      ]
+    end
+  end
+
   context "for the owner" do
     let(:user) { User.make! }
     subject { described_class.new(user, Mobilization.make!(user: user)) }

--- a/spec/policies/widget_policy_spec.rb
+++ b/spec/policies/widget_policy_spec.rb
@@ -92,6 +92,49 @@ RSpec.describe WidgetPolicy do
     end
   end
 
+  context "for a user in Community's list" do
+    let(:user) { User.make! admin: true }
+    let(:mobilization) { Mobilization.make! user: user }
+    let(:block) { Block.make! mobilization: mobilization }
+    subject { described_class.new(user, Widget.make!(block: block)) }
+
+    before { CommunityUser.create! user_id: user.id, community_id: mobilization.community.id, role: 1}
+
+    it { should allows(:index) }
+    it { should allows(:show) }
+    it { should allows(:create) }
+    it { should allows(:new) }
+    it { should allows(:update) }
+    it { should allows(:edit) }
+    it { should allows(:destroy) }
+    it "should have complete scope" do
+      expect(subject.scope).to eq Widget
+    end
+    it "should return permitted attributes" do
+      expect(subject.permitted_attributes).to eq permitted_attributes
+    end
+  end
+
+  context "for an admin" do
+    let(:user) { User.make! admin: true }
+    let(:mobilization) { Mobilization.make! user: user }
+    let(:block) { Block.make! mobilization: mobilization }
+    subject { described_class.new(user, Widget.make!(block: block)) }
+    it { should allows(:index) }
+    it { should allows(:show) }
+    it { should allows(:create) }
+    it { should allows(:new) }
+    it { should allows(:update) }
+    it { should allows(:edit) }
+    it { should allows(:destroy) }
+    it "should have complete scope" do
+      expect(subject.scope).to eq Widget
+    end
+    it "should return permitted attributes" do
+      expect(subject.permitted_attributes).to eq permitted_attributes
+    end
+  end
+
   context "for the owner" do
     let(:user) { User.make! }
     let(:mobilization) { Mobilization.make! user: user }


### PR DESCRIPTION
Lembrar de retirar o admin de todos os usuários que não forem administradores, pois esses terão acesso à todas as comunidades