### PR TITLE
Issue #181 Remove from autofire emails unsubscribe links

### DIFF
--- a/app/mailers/activist_pressure_mailer.rb
+++ b/app/mailers/activist_pressure_mailer.rb
@@ -17,19 +17,19 @@ class ActivistPressureMailer < ApplicationMailer
       @activist = activist_pressure.activist
       @mail = recipient
       headers['X-SMTPAPI'] = %#{
-      "filters": {
-        "subscriptiontrack": {
-          "settings": {
-            "enable": 0
-          }
-        },
-        "bypass_list_management" : {
-          "settings" : {
-            "enable" : 1
+        "filters": {
+          "subscriptiontrack": {
+            "settings": {
+              "enable": 0
+            }
+          },
+          "bypass_list_management" : {
+            "settings" : {
+              "enable" : 1
+            }
           }
         }
-      }
-    }#
+      }#
       mail to: targets, subject: @mail[:subject], from: activist_email
     end
   end

--- a/app/mailers/donations_mailer.rb
+++ b/app/mailers/donations_mailer.rb
@@ -12,6 +12,21 @@ class DonationsMailer < ApplicationMailer
 
       from_address = sender ? "#{sender} <#{email_address}>" : email_address
 
+      headers['X-SMTPAPI'] = %#{
+        "filters": {
+          "subscriptiontrack": {
+            "settings": {
+              "enable": 0
+            }
+          },
+          "bypass_list_management" : {
+            "settings" : {
+              "enable" : 1
+            }
+          }
+        }
+      }#
+
       mail(
         to: donation.customer['email'],
         subject: subject,

--- a/app/mailers/form_entry_mailer.rb
+++ b/app/mailers/form_entry_mailer.rb
@@ -13,6 +13,16 @@ class FormEntryMailer < ApplicationMailer
                   @mobilization.name
                 end
 
+      headers['X-SMTPAPI'] = %#{
+        "filters": {
+          "subscriptiontrack": {
+            "settings": {
+              "enable": 0
+            }
+          }
+        }
+      }#
+
       mail(
         to: form_entry.email,
         subject: subject,


### PR DESCRIPTION
Removing unsubscribe links from autofired emails. Since we user sendgrid, I'd used the sendgrod smtp api. To test, one may subscribe something, or even call "send_email" from an FormEntry, ActivistPressure or Donation.