### PR TITLE
Closing Issue #186 - Adding widget info on post /mobilization/:mob_id/blocks

### DIFF
--- a/app/controllers/mobilizations/blocks_controller.rb
+++ b/app/controllers/mobilizations/blocks_controller.rb
@@ -11,7 +11,7 @@ class Mobilizations::BlocksController < ApplicationController
     @block = Block.new(block_params.merge(mobilization_id: params[:mobilization_id]))
     authorize @block
     @block.save!
-    render json: @block
+    render json: @block , serializer: BlockSerializer::CompleteBlockSerializer
   end
 
   def update

--- a/app/serializers/block_serializer.rb
+++ b/app/serializers/block_serializer.rb
@@ -1,0 +1,11 @@
+class BlockSerializer < ActiveModel::Serializer
+    attributes :id, :mobilization_id, :created_at, :updated_at, :bg_class, :position, :hidden, :bg_image, :name, :menu_hidden
+
+  class CompleteBlockSerializer < ActiveModel::Serializer
+    attributes :id, :mobilization_id, :created_at, :updated_at, :bg_class, :position, :hidden, :bg_image, :name, :menu_hidden, :widgets_attributes
+
+    def widgets_attributes
+      object.widgets 
+    end
+  end
+end

--- a/spec/controllers/mobilizations/blocks_controller_spec.rb
+++ b/spec/controllers/mobilizations/blocks_controller_spec.rb
@@ -25,17 +25,19 @@ RSpec.describe Mobilizations::BlocksController, type: :controller do
       mobilization = Mobilization.make!
       expect(mobilization.blocks.count).to eq(0)
       post :create, mobilization_id: mobilization.id, format: :json
+
       expect(mobilization.blocks.count).to eq(1)
-      expect(response.body).to include(mobilization.blocks.first.to_json)
+      expect(response.body).to include(BlockSerializer::CompleteBlockSerializer.new(mobilization.blocks.first).to_json)
     end
 
     it "should create with JSON format and parameters" do
       mobilization = Mobilization.make!
       expect(mobilization.blocks.count).to eq(0)
       post :create, mobilization_id: mobilization.id, format: :json, block: { position: 12345, bg_class: 'bg-yellow', bg_image: 'foobar.jpg', hidden: true }
+
       expect(mobilization.blocks.count).to eq(1)
       block = mobilization.blocks.first
-      expect(response.body).to include(block.to_json)
+      expect(response.body).to include(BlockSerializer::CompleteBlockSerializer.new(block).to_json)
       expect(block.position).to eq(12345)
       expect(block.bg_class).to eq('bg-yellow')
       expect(block.bg_image).to eq('foobar.jpg')
@@ -48,7 +50,7 @@ RSpec.describe Mobilizations::BlocksController, type: :controller do
       post :create, mobilization_id: mobilization.id, format: :json, block: { widgets_attributes: [{kind: 'content', sm_size: 8, md_size: 6, lg_size: 6}, {kind: 'weather', sm_size: 12, md_size: 12, lg_size: 4}] }
       expect(mobilization.blocks.count).to eq(1)
       block = mobilization.blocks.first
-      expect(response.body).to include(block.to_json)
+      expect(response.body).to include(BlockSerializer::CompleteBlockSerializer.new(block).to_json)
       expect(block.widgets.count).to eq(2)
       widget1 = block.widgets[0]
       widget2 = block.widgets[1]


### PR DESCRIPTION
Adding widget information as requested on /mobilization/:mob_id/blocks

Description about routes and payloads on issue #186 .

This close #186 .