### PR TITLE
Add whatsapp_text into widget policy

### DIFF
--- a/app/policies/widget_policy.rb
+++ b/app/policies/widget_policy.rb
@@ -17,6 +17,8 @@ class WidgetPolicy < ApplicationPolicy
         :show_counter,
 
         # Settings specific widget
+        :whatsapp_text,
+
         # Content Widget
         :content,
 

--- a/spec/policies/widget_policy_spec.rb
+++ b/spec/policies/widget_policy_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe WidgetPolicy do
     :show_counter,
 
     # Settings specific widget
+    :whatsapp_text,
+
     # Content Widget
     :content,
 


### PR DESCRIPTION
# Introduction
Accepts `whatsapp_text` attribute received via payload to manipulate widget.

# Related issues
Dependent on nossas/bonde-client#487