### PR TITLE
Feature form entries to csv

### DIFF
--- a/app/controllers/mobilizations/form_entries_controller.rb
+++ b/app/controllers/mobilizations/form_entries_controller.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 class Mobilizations::FormEntriesController < ApplicationController
   respond_to :json
   after_action :verify_policy_scoped, only: %i[]
@@ -17,7 +19,16 @@ class Mobilizations::FormEntriesController < ApplicationController
       end
     end
 
-    render json: @form_entries.to_json
+    @form_entries = disjoint_fields if params[:INFO] == 'disjoint_fields'
+
+    respond_with do |format|
+      format.html { render json: @form_entries }
+      format.json { render json: @form_entries }
+
+      format.csv do
+        send_data to_csv(@form_entries), type: Mime::CSV, disposition: "attachment; filename=form_entries_#{DateTime.now.to_i}_#{parent.community.name.parameterize}_#{parent.id}.csv"
+      end
+    end
   end
 
   def create
@@ -30,11 +41,43 @@ class Mobilizations::FormEntriesController < ApplicationController
 
   private
 
+  def to_csv data
+    fst =  data.first
+    if fst.is_a? Hash
+      CSV.generate(headers: true) do |csv|
+        csv << fst.keys
+
+        data.each do |fe|
+          csv << fe
+        end
+      end
+    else
+      CSV.generate(headers: true) do |csv|
+        csv << fst.attributes.keys
+
+        data.each do |fe|
+          csv << fe.attributes.values
+        end
+      end
+    end
+  end
+
   def form_entry_params
     params.require(:form_entry).permit(*policy(@form_entry || FormEntry.new).permitted_attributes)
   end
 
   def parent
     @mobilization ||= policy_scope(Mobilization).find params[:mobilization_id]
+  end
+
+  def disjoint_fields 
+    @form_entries.map do |form_entry|
+      custom_fields = JSON.parse(form_entry.fields).map{|f| [f['label'], f['value']] }.to_h
+      fixed_attributes = form_entry.attributes
+      fixed_attributes.delete 'fields'
+      fixed_attributes.delete 'synchronized'
+      fixed_attributes['requester'] = current_user.id
+      Hash[fixed_attributes.merge(custom_fields).sort.to_h]
+    end
   end
 end

--- a/spec/controllers/mobilizations/form_entries_controller_spec.rb
+++ b/spec/controllers/mobilizations/form_entries_controller_spec.rb
@@ -16,20 +16,57 @@ RSpec.describe Mobilizations::FormEntriesController, type: :controller do
   end
 
   describe "GET #index" do
-    context "when access with user" do
-      let!(:form_entry) { FormEntry.make! widget: widget }
-      let!(:form_entry2) { FormEntry.make! widget: widget2 }
+    context 'with full_info flag' do
+      context "when access with user" do
+        let!(:form_entry) { FormEntry.make! widget: widget }
+        let!(:form_entry2) { FormEntry.make! widget: widget2 }
+
+        def fields_generated(fe)
+          {
+            'activist_id' => fe.activist_id,
+            'created_at' => fe.created_at,
+            'email' => 'zemane@naoexiste.com',
+            'first name' => 'José',
+            'id' => fe.id,
+            'last name' => 'manuel',
+            'requester' => current_user.id,
+            'updated_at' => fe.updated_at,
+            'widget_id' => fe.widget_id
+          }
+        end
 
         it "should return form_entries by mobilization" do
-        get(:index, mobilization_id: mobilization.id)
-        expect(response.body).to eq([form_entry, form_entry2].to_json)
-      end
+          get(:index, { mobilization_id: mobilization.id, INFO: 'disjoint_fields' })
+          expect(assigns(:form_entries)).to eq([fields_generated(form_entry), fields_generated(form_entry2)])
+        end
 
-      it "should return form_entries by widget_id" do
-        get(:index, mobilization_id: mobilization.id, widget_id: widget.id)
-        widget.reload
-        expect(response.body).to eq([form_entry].to_json)
-        expect(widget.exported_at).not_to eq(nil)
+        it "should return form_entries by widget_id" do
+          get(:index, { mobilization_id: mobilization.id, widget_id: widget.id, INFO: 'disjoint_fields'})
+
+          widget.reload
+          expect(assigns(:form_entries)).to eq([fields_generated(form_entry)])
+          expect(widget.exported_at).not_to eq(nil)
+        end
+      end
+    end
+
+    context 'without INFO' do
+      context "when access with user" do
+        let!(:form_entry) { FormEntry.make! widget: widget }
+        let!(:form_entry2) { FormEntry.make! widget: widget2 }
+
+        it "should return form_entries by mobilization" do
+          get(:index, mobilization_id: mobilization.id)
+          expect(assigns(:form_entries)).to eq([form_entry, form_entry2])
+        end
+
+        it "should return form_entries by widget_id" do
+          get(:index, mobilization_id: mobilization.id, widget_id: widget.id)
+
+          widget.reload
+          expect(assigns(:form_entries)).to eq([form_entry])
+          expect(widget.exported_at).not_to eq(nil)
+        end
       end
     end
   end

--- a/spec/factories/mobilization.rb
+++ b/spec/factories/mobilization.rb
@@ -29,7 +29,7 @@ FactoryGirl.define do
     lg_size { 12 }
     kind { "content" }
     action_community { false }
-    settings { {content: "My 12 columns widget", other: "#{sn}"} }
+    sequence(:settings) {|sn| {content: "My 12 columns widget", other: "#{sn}"} }
   end
 
   factory :match, class: Match do

--- a/spec/requests/mobilizations/form_entries.rb
+++ b/spec/requests/mobilizations/form_entries.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe "FormEntries", type: :request do
+  # before do
+  #   allow_any_instance_of(DnsService).to receive(:create_hosted_zone).and_return({
+  #     'delegation_set' => { 'name_servers' => ["ns-1258.awsdns-29.org", "ns-826.awsdns-39.net", "ns-55.awsdns-06.com", "ns-1552.awsdns-02.co.uk"] },
+  #     'hosted_zone' => {'id' => '12312312'}
+  #   })
+
+  #   allow_any_instance_of(DnsService).to receive(:change_resource_record_sets)
+  # end
+  # let!(:dns_record) { create(:dns_record) }
+
+  # describe "GET /communities/:community_id/dns_hosted_zones/:dns_hosted_zone_id/dns_records" do
+  #   it "works!" do
+  #     get community_dns_hosted_zone_dns_records_path community_id: dns_record.community.id, 
+  #       dns_hosted_zone_id: dns_record.dns_hosted_zone.id
+  #     expect(response).to have_http_status(200)
+  #   end
+  # end
+  let(:user) { create(:user) }
+
+  before { stub_current_user(user) }
+
+  describe 'GET /mobilizations/:mobilization_id/form_entries' do
+    let!(:widget) { create :widget }
+
+    let!(:form_entry_1) { create :form_entry, widget: widget }
+    let!(:form_entry_2) { create :form_entry }
+
+    context 'format csv joint_fields' do
+      before { get "/mobilizations/#{widget.mobilization.id}/form_entries.csv?widget_id=#{widget.id}&INFO=disjoint_fields" }
+
+      it { expect(response).to have_http_status(200) }
+
+      it do
+        expect(response.body).to include('email')
+        expect(response.body).to include('first name')
+        expect(response.body).to include('last name')
+        expect(response.body).not_to include('fields')
+      end
+    end
+
+    context 'format csv' do
+      before { get "/mobilizations/#{widget.mobilization.id}/form_entries.csv?widget_id=#{widget.id}" }
+
+      it { expect(response).to have_http_status(200) }
+
+      it do
+        expect(response.body).to include('fields')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Uses the same endpoint:

get "/mobilizations/#{widget.mobilization.id}/form_entries.csv?widget_id=#{widget.id}&INFO=disjoint_fields"

To get csv format, put the ".csv" after URL, but before the parameters.
To export FIELDS, as properties, you use the  INFO=disjoint_fields