### PR TITLE
Issue #247 - Filter subdomains to remove bonde default entries

### DIFF
--- a/spec/controllers/dns_records_controller_spec.rb
+++ b/spec/controllers/dns_records_controller_spec.rb
@@ -48,10 +48,29 @@ RSpec.describe DnsRecordsController, type: :controller do
   let(:valid_session) { {} }
 
   describe "GET #index" do
+    let!(:dns_records) { [
+      create(:dns_record, name: "#{dns_hosted_zone.domain_name}", record_type: 'SOA', dns_hosted_zone: dns_hosted_zone),
+      create(:dns_record, name: "#{dns_hosted_zone.domain_name}", record_type: 'NS', dns_hosted_zone: dns_hosted_zone),
+      create(:dns_record, name: "#{dns_hosted_zone.domain_name}", record_type: 'A', dns_hosted_zone: dns_hosted_zone),
+      create(:dns_record, name: "#{dns_hosted_zone.domain_name}", record_type: 'AAAA', dns_hosted_zone: dns_hosted_zone),
+      create(:dns_record, name: "*.#{dns_hosted_zone.domain_name}", record_type: 'A', dns_hosted_zone: dns_hosted_zone),
+      create(:dns_record, name: "*.#{dns_hosted_zone.domain_name}", record_type: 'AAAA', dns_hosted_zone: dns_hosted_zone),
+      create(:dns_record, name: "*.#{dns_hosted_zone.domain_name}", record_type: 'CNAME', dns_hosted_zone: dns_hosted_zone),
+      create(:dns_record, dns_hosted_zone: dns_hosted_zone)
+    ] }
+
     it "assigns all dns_records as @dns_records" do
-      dns_record = create(:dns_record, dns_hosted_zone: dns_hosted_zone)
+      get :index, { dns_hosted_zone_id: dns_hosted_zone.id, community_id: community.id, full_data: 'true'}
+
+      dns_records.each{|r| expect(assigns(:dns_records)).to include(r) }
+      expect(assigns(:dns_records).size).to be dns_records.size
+    end
+
+    it "assigns all dns_records as @dns_records" do
       get :index, { dns_hosted_zone_id: dns_hosted_zone.id, community_id: community.id}
-      expect(assigns(:dns_records)).to eq([dns_record])
+
+      dns_records.each{|r| expect(assigns(:dns_records)).to include(dns_records.last) }
+      expect(assigns(:dns_records).size).to be 1
     end
   end
 

--- a/spec/requests/dns_records_spec.rb
+++ b/spec/requests/dns_records_spec.rb
@@ -15,11 +15,23 @@ RSpec.describe "DnsRecords", type: :request do
   let(:dns_record) { create(:dns_record) }
 
   describe "GET /communities/:community_id/dns_hosted_zones/:dns_hosted_zone_id/dns_records" do
-    it "works!" do
+    describe "Found" do
+      before { get community_dns_hosted_zone_dns_records_path community_id: dns_record.community.id, 
+              dns_hosted_zone_id: dns_record.dns_hosted_zone.id }
 
-      get community_dns_hosted_zone_dns_records_path community_id: dns_record.community.id, 
+      it { expect(response).to have_http_status(200) }
+    end
+
+    it "inexistent community" do
+      get community_dns_hosted_zone_dns_records_path community_id: 0, 
         dns_hosted_zone_id: dns_record.dns_hosted_zone.id
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(404)
+    end
+
+    it "inexistent hosted_zone" do
+      get community_dns_hosted_zone_dns_records_path community_id: dns_record.community.id, 
+        dns_hosted_zone_id: 0
+      expect(response).to have_http_status(404)
     end
   end
 end


### PR DESCRIPTION
GET /communities/:community_id/dns_hosted_zones/:dns_hosted_zone_id/dns_records(.:format)
This will bring data without the default entries

GET /communities/:community_id/dns_hosted_zones/:dns_hosted_zone_id/dns_records(.:format)?full_data=true
This will bring all data