### PR TITLE
enable usage of email_template_from field on community api

### DIFF
--- a/app/policies/community_policy.rb
+++ b/app/policies/community_policy.rb
@@ -1,6 +1,6 @@
 class CommunityPolicy < ApplicationPolicy
   def permitted_attributes
-    [:name, :city, :pagarme, :transfer_day, :transfer_enabled, :image, :description, :mailchimp_api_key, :mailchimp_list_id, :mailchimp_group_id, :facebook_app_id, :fb_link, :twitter_link, :subscription_dead_days_interval, :subscription_retry_interval]
+    [:name, :city, :pagarme, :transfer_day, :transfer_enabled, :image, :description, :mailchimp_api_key, :mailchimp_list_id, :mailchimp_group_id, :facebook_app_id, :fb_link, :twitter_link, :subscription_dead_days_interval, :subscription_retry_interval, :email_template_from]
   end
 
   def can_handle_with_payables?

--- a/app/serializers/community_serializer.rb
+++ b/app/serializers/community_serializer.rb
@@ -1,5 +1,5 @@
 class CommunitySerializer < ActiveModel::Serializer
-  attributes :id, :name, :city, :mailchimp_api_key, :mailchimp_list_id, :mailchimp_group_id, :image, :description, :recipient, :facebook_app_id, :subscription_dead_days_interval, :subscription_retry_interval
+  attributes :id, :name, :city, :mailchimp_api_key, :mailchimp_list_id, :mailchimp_group_id, :image, :description, :recipient, :facebook_app_id, :subscription_dead_days_interval, :subscription_retry_interval, :email_template_from
 
   include PagarmeHelper
 

--- a/spec/controllers/communities_controller_spec.rb
+++ b/spec/controllers/communities_controller_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'rails_helper'
 
 RSpec.describe CommunitiesController, type: :controller do
@@ -34,7 +35,8 @@ RSpec.describe CommunitiesController, type: :controller do
             description: 'A community to solve ours problems',
             mailchimp_api_key: 'abc56',
             mailchimp_list_id: '1234',
-            mailchimp_group_id: '7890'
+            mailchimp_group_id: '7890',
+            email_template_from: 'Lorem <lorem@lorem.com>'
           }}
       before do
         @count = Community.count
@@ -53,9 +55,10 @@ RSpec.describe CommunitiesController, type: :controller do
       end
 
       it 'should return the data saved' do
+        dt = JSON.parse response.body
+
         vals.each do |f, v|
-          expect(response.body).to include(f.to_s)
-          expect(response.body).to include(v)
+          expect(dt[f.to_s]).to eq(v)
         end
       end
 
@@ -66,6 +69,7 @@ RSpec.describe CommunitiesController, type: :controller do
         expect(saved.mailchimp_api_key).to eq('abc56')
         expect(saved.mailchimp_list_id).to eq('1234')
         expect(saved.mailchimp_group_id).to eq('7890')
+        expect(saved.email_template_from.html_safe).to eq('Lorem <lorem@lorem.com>')
         expect(saved.description).to eq('A community to solve ours problems')
         expect(saved.city).to eq('Pindamonhangaba, SP')
         expect(saved.name).to eq('José Marculino Silva')


### PR DESCRIPTION
field address format name \<address@provider.com\>