### PR TITLE
Hotfix community invitation

### DIFF
--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -103,16 +103,12 @@ class CommunitiesController < ApplicationController
 
   def accept_invitation
     skip_authorization
-    invitation = Invitation.find_by_email_and_code params['email'], params['code']
-    if invitation
-      begin
-        render json: (@community_user = invitation.create_community_user), serializer: CommunityUserSerializer::CommunityUserSimpleSerializer
-      rescue InvitationException
-        render nothing: true, status: 412
-      end
-    else
-      render nothing: true, status: :not_found
-    end
+    invitation = Invitation.find_by(
+      email: params['email'],
+      code: params['code'])
+    invitation.create_community_user if invitation
+
+    redirect_to (Rails.env.staging? ? 'https://staging.bonde.org' : 'https://app.bonde.org')
   end
 
   def create_invitation

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -28,13 +28,15 @@ class Invitation < ActiveRecord::Base
     end
 
     invited_user = User.find_by_email self.email
-    invited_user = generate_user unless invited_user
+    #invited_user = generate_user unless invited_user
 
-    community_user = CommunityUser.create! user: invited_user, community: self.community, role: self.role
-    self.expired = true
-    self.save!
+    if invited_user
+      community_user = CommunityUser.create! user: invited_user, community: self.community, role: self.role
+      self.expired = true
+      self.save!
 
-    community_user
+      community_user
+    end
   end
 
   private

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -22,15 +22,15 @@ class Invitation < ActiveRecord::Base
   end
 
   def create_community_user
-    if invitation_expired?
-      self.update_attributes expired: true if (! self.expired)
-      raise InvitationException.new(I18n.t 'activerecord.errors.models.invitation.create_community_user')
-    end
-
     invited_user = User.find_by_email self.email
     #invited_user = generate_user unless invited_user
 
     if invited_user
+       if invitation_expired?
+         self.update_attributes expired: true if (! self.expired)
+         return
+       end
+
       community_user = CommunityUser.create! user: invited_user, community: self.community, role: self.role
       self.expired = true
       self.save!
@@ -51,7 +51,4 @@ class Invitation < ActiveRecord::Base
   def invitation_expired?
     expired? || ( expires < DateTime.now )
   end
-end
-
-class InvitationException < RuntimeError
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,7 +23,7 @@ user_admin = User.find_or_create_by(email: 'admin_foo@bar.com') do |u|
   u.first_name = 'admin Foo'
   u.last_name = 'Bar'
   u.admin = true
-  u.skip_confirmation!
+#  u.skip_confirmation!
 end
 
 communities = Community.create([

--- a/spec/controllers/communities_controller_spec.rb
+++ b/spec/controllers/communities_controller_spec.rb
@@ -819,29 +819,14 @@ RSpec.describe CommunitiesController, type: :controller do
         expect{ call_accept }.to change{ CommunityUser.count }.by(1)
       end
 
-      it 'should expose the created data' do
-        call_accept      
-        expect(assigns(:community_user)).to eq(CommunityUser.last)
+      it 'should redirect after request' do
+        expect(call_accept).to be_redirect
       end
     end
 
     context 'invited user don\'t exists' do
-      it 'should create new user' do
-        expect{ call_accept }.to change{ User.count }.by(1)
-      end
-
-      xit 'should send an email to the new user' do
-          expect{ call_accept }.to change { ActionMailer::Base.deliveries.count }.by(1)
-      end
-
-
-      it 'should create new community_user' do
-        expect{ call_accept }.to change{ CommunityUser.count }.by(1)
-      end
-
-      it 'should expose the created data' do
-        call_accept      
-        expect(assigns(:community_user)).to eq(CommunityUser.last)
+      it 'should not create community_user' do
+        expect{ call_accept }.to change{ CommunityUser.count }.by(0)
       end
     end
   end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -58,32 +58,32 @@ RSpec.describe Invitation, type: :model do
         it 'should turn invitation\'s expired to true' do
           subject.create_community_user
           subject.reload
-          expect(subject.expired).to be
+          expect(subject.expired).to eq(true)
         end
       end
 
       context 'without user' do
-        it 'should create an User' do
+        it 'should not create an User' do
           subject
-          expect{subject.create_community_user}.to change{User.count}.by(1)
+          expect{subject.create_community_user}.not_to change{User.count}
         end
-  
-        it 'should create a correct instance' do
+
+        it 'should not return nil' do
           community_user = subject.create_community_user
 
-          expect(community_user.community_id).to eq(subject.community_id)
-          expect(community_user.role).to eq(subject.role)
+          expect(community_user).to eq(nil)
         end
 
-        it 'should turn invitation\'s expired to true' do
+        it 'should not turn invitation\'s expired to true' do
           subject.create_community_user
           subject.reload
-          expect(subject.expired).to be
+          expect(subject.expired).to eq(false)
         end
       end
     end
 
     context 'expired' do
+      before { create :user, email: subject.email }
       it do
         subject.expired = true
         expect{subject.create_community_user}.to raise_error(InvitationException)
@@ -97,7 +97,7 @@ RSpec.describe Invitation, type: :model do
       it 'should turn invitation\'s expired to true' do
         subject.create_community_user
         subject.reload
-        expect(subject.expired).to be
+        expect(subject.expired).to eq(true)
       end
     end
   end


### PR DESCRIPTION
- disable user generation when email is not from a registered user
- fixes specs
- should redirect to app.bonde.org after invitation process link