### PR TITLE
Feature facebook bot campaigns

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -66,7 +66,7 @@ pipeline:
   notify:
     image: plugins/slack
     webhook: https://hooks.slack.com/services/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
-    channel: n_tech
+    channel: bonde_bots
     username: CI - ${DRONE_REPO_NAME}
     when:
       event: [ push, tag, build, publish, deployment, pull_request ]

--- a/db/migrate/20170929162447_create_facebook_bot_campaigns.rb
+++ b/db/migrate/20170929162447_create_facebook_bot_campaigns.rb
@@ -1,0 +1,12 @@
+class CreateFacebookBotCampaigns < ActiveRecord::Migration
+  def change
+    create_table :facebook_bot_campaigns do |t|
+      t.references :facebook_bot_configuration, index: true, foreign_key: true, null: false
+      t.text :name, null: false
+      t.jsonb :segment_filters, null: false
+      t.integer :total_impacted_activists, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20170929163823_create_facebook_bot_campaign_activists.rb
+++ b/db/migrate/20170929163823_create_facebook_bot_campaign_activists.rb
@@ -1,0 +1,22 @@
+class CreateFacebookBotCampaignActivists < ActiveRecord::Migration
+  def change
+    create_table :facebook_bot_campaign_activists do |t|
+      t.references(
+        :facebook_bot_campaign,
+        index: { name: 'idx_facebook_bot_campaign_activists_on_facebook_bot_campaign_id' },
+        foreign_key: true,
+        null: false
+      )
+      t.references(
+        :facebook_bot_activist,
+        index: { name: 'idx_facebook_bot_campaign_activists_on_facebook_bot_activist_id' },
+        foreign_key: true,
+        null: false
+      )
+      t.boolean :received, null: false, default: false
+      t.jsonb :log, default: "{}"
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20171109153428_add_facebook_bot_activists_fetch_strategy_to_postgraphql.rb
+++ b/db/migrate/20171109153428_add_facebook_bot_activists_fetch_strategy_to_postgraphql.rb
@@ -1,0 +1,251 @@
+class AddFacebookBotActivistsFetchStrategyToPostgraphql < ActiveRecord::Migration
+  def up
+    execute %Q{
+ALTER TYPE postgraphql.facebook_activist_search_result_type ADD ATTRIBUTE id integer;
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_by_date_interval(
+    date_interval_start timestamp,
+    date_interval_end timestamp
+)
+    RETURNS setof postgraphql.facebook_activist_search_result_type
+    LANGUAGE sql
+    IMMUTABLE
+AS $function$
+    SELECT DISTINCT
+        fb_context_recipient_id,
+        fb_context_sender_id,
+        data,
+        messages,
+        quick_replies,
+        created_at,
+        updated_at,
+        id
+    FROM (
+        SELECT *, UNNEST(interaction_dates) as interaction_date
+        FROM public.facebook_bot_activists
+    ) as a
+    WHERE interaction_date::date BETWEEN date_interval_start AND date_interval_end
+    ORDER BY updated_at;
+$function$;
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_by_quick_reply(quick_reply text)
+    RETURNS setof postgraphql.facebook_activist_search_result_type
+    LANGUAGE sql
+    IMMUTABLE
+AS $function$
+    SELECT
+        fb_context_recipient_id,
+        fb_context_sender_id,
+        data,
+        messages,
+        quick_replies,
+        created_at,
+        updated_at,
+        id
+    FROM public.facebook_bot_activists
+    WHERE quick_reply = ANY(quick_replies)
+    ORDER BY updated_at DESC;
+$function$;
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_by_message_quick_reply(
+    message text,
+    quick_reply text
+)
+    RETURNS setof postgraphql.facebook_activist_search_result_type
+    LANGUAGE sql
+    IMMUTABLE
+AS $function$
+    SELECT
+        fb_context_recipient_id,
+        fb_context_sender_id,
+        data,
+        messages,
+        quick_replies,
+        created_at,
+        updated_at,
+        id
+    FROM public.facebook_bot_activists
+    WHERE
+        messages @@ plainto_tsquery('portuguese', message) AND
+        quick_reply = ANY(quick_replies)
+    ORDER BY updated_at DESC;
+$function$;
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_by_message(message text)
+    RETURNS setof postgraphql.facebook_activist_search_result_type
+    LANGUAGE sql
+    IMMUTABLE
+AS $function$
+    SELECT
+        fb_context_recipient_id,
+        fb_context_sender_id,
+        data,
+        messages,
+        quick_replies,
+        created_at,
+        updated_at,
+        id
+    FROM public.facebook_bot_activists
+    WHERE messages @@ plainto_tsquery('portuguese', message)
+    ORDER BY updated_at DESC;
+$function$;
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_strategy(search jsonb)
+RETURNS setof postgraphql.facebook_activist_search_result_type
+LANGUAGE plpgsql
+IMMUTABLE
+AS $function$
+    DECLARE
+        _message text := search ->> 'message';
+        _quickReply text := search ->> 'quickReply';
+        _dateIntervalStart timestamp := search ->> 'dateIntervalStart';
+        _dateIntervalEnd timestamp := search ->> 'dateIntervalEnd';
+        _m boolean := _message IS NOT NULL;
+        _qr boolean := _quickReply IS NOT NULL;
+        _start boolean := _dateIntervalStart IS NOT NULL;
+        _end boolean := _dateIntervalEnd IS NOT NULL;
+        _is_only_message boolean :=               _m  AND (NOT _qr) AND (NOT _start) AND (NOT _end);
+        _is_only_q_reply boolean :=          (NOT _m) AND      _qr  AND (NOT _start) AND (NOT _end);
+        _is_only_date_interval boolean :=    (NOT _m) AND (NOT _qr) AND      _start  AND      _end;
+        _is_q_reply_date_interval boolean := (NOT _m) AND      _qr  AND       _start AND      _end;
+        _is_message_date_interval boolean :=      _m  AND (NOT _qr) AND      _start  AND      _end;
+        _is_message_q_reply boolean :=            _m  AND      _qr  AND (NOT _start) AND (NOT _end);
+        _is_all boolean :=                        _m  AND      _qr  AND      _start  AND      _end;
+    BEGIN
+        IF _is_only_message THEN RETURN QUERY (
+            SELECT * FROM postgraphql.get_facebook_activists_by_message(_message)
+        );
+        ELSIF _is_only_q_reply THEN RETURN QUERY (
+            SELECT * FROM postgraphql.get_facebook_activists_by_quick_reply(_quickReply)
+        );
+        ELSIF _is_only_date_interval THEN RETURN QUERY (
+            SELECT * FROM postgraphql.get_facebook_activists_by_date_interval(
+                _dateIntervalStart,
+                _dateIntervalEnd
+            )
+        );
+        ELSIF _is_q_reply_date_interval THEN RETURN QUERY (
+            SELECT * FROM postgraphql.get_facebook_activists_by_quick_reply_date_interval(
+                _quickReply,
+                _dateIntervalStart,
+                _dateIntervalEnd
+            )
+        );
+        ELSIF _is_message_date_interval THEN RETURN QUERY (
+            SELECT * FROM postgraphql.get_facebook_activists_by_message_date_interval(
+                _message,
+                _dateIntervalStart,
+                _dateIntervalEnd
+            )
+        );
+        ELSIF _is_message_q_reply THEN RETURN QUERY (
+            SELECT * FROM postgraphql.get_facebook_activists_by_message_quick_reply(
+                _message,
+                _quickReply
+            )
+        );
+        ELSIF _is_all THEN RETURN QUERY (
+            SELECT * FROM postgraphql.get_facebook_activists_by_message_quick_reply_date_interval(
+                _message,
+                _quickReply,
+                _dateIntervalStart,
+                _dateIntervalEnd
+            )
+        );
+        END IF;
+    END;
+$function$;
+}
+  end
+
+  def down
+    execute %Q{
+DROP FUNCTION postgraphql.get_facebook_activists_strategy(data jsonb);
+
+ALTER TYPE postgraphql.facebook_activist_search_result_type DROP ATTRIBUTE IF EXISTS id;
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_by_message(message text)
+    RETURNS setof postgraphql.facebook_activist_search_result_type
+    LANGUAGE sql
+    IMMUTABLE
+AS $function$
+    SELECT
+        fb_context_recipient_id,
+        fb_context_sender_id,
+        data,
+        messages,
+        quick_replies,
+        created_at,
+        updated_at
+    FROM public.facebook_bot_activists
+    WHERE messages @@ plainto_tsquery('portuguese', message)
+    ORDER BY updated_at DESC;
+$function$;
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_by_message_quick_reply(
+    message text,
+    quick_reply text
+)
+    RETURNS setof postgraphql.facebook_activist_search_result_type
+    LANGUAGE sql
+    IMMUTABLE
+AS $function$
+    SELECT
+        fb_context_recipient_id,
+        fb_context_sender_id,
+        data,
+        messages,
+        quick_replies,
+        created_at,
+        updated_at
+    FROM public.facebook_bot_activists
+    WHERE
+        messages @@ plainto_tsquery('portuguese', message) AND
+        quick_reply = ANY(quick_replies)
+    ORDER BY updated_at DESC;
+$function$;
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_by_quick_reply(quick_reply text)
+    RETURNS setof postgraphql.facebook_activist_search_result_type
+    LANGUAGE sql
+    IMMUTABLE
+AS $function$
+    SELECT
+        fb_context_recipient_id,
+        fb_context_sender_id,
+        data,
+        messages,
+        quick_replies,
+        created_at,
+        updated_at
+    FROM public.facebook_bot_activists
+    WHERE quick_reply = ANY(quick_replies)
+    ORDER BY updated_at DESC;
+$function$;
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_by_date_interval(
+    date_interval_start timestamp,
+    date_interval_end timestamp
+)
+    RETURNS setof postgraphql.facebook_activist_search_result_type
+    LANGUAGE sql
+    IMMUTABLE
+AS $function$
+    SELECT DISTINCT
+        fb_context_recipient_id,
+        fb_context_sender_id,
+        data,
+        messages,
+        quick_replies,
+        created_at,
+        updated_at
+    FROM (
+        SELECT *, UNNEST(interaction_dates) as interaction_date
+        FROM public.facebook_bot_activists
+    ) as a
+    WHERE interaction_date::date BETWEEN date_interval_start AND date_interval_end
+    ORDER BY updated_at;
+$function$;
+}
+  end
+end

--- a/db/migrate/20171109154132_add_facebook_bot_campaign_actions_to_postgraphql.rb
+++ b/db/migrate/20171109154132_add_facebook_bot_campaign_actions_to_postgraphql.rb
@@ -1,0 +1,86 @@
+class AddFacebookBotCampaignActionsToPostgraphql < ActiveRecord::Migration
+  def up
+    execute %Q{
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.facebook_bot_campaigns TO admin, common_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.facebook_bot_campaign_activists TO admin, common_user;
+GRANT USAGE ON SEQUENCE public.facebook_bot_campaigns_id_seq TO admin, common_user;
+GRANT USAGE ON SEQUENCE public.facebook_bot_campaign_activists_id_seq TO admin, common_user;
+
+CREATE TYPE postgraphql.facebook_bot_campaigns_type AS (
+  facebook_bot_configuration_id integer,
+  name text,
+  segment_filters jsonb,
+  total_impacted_activists integer
+);
+
+CREATE OR REPLACE FUNCTION postgraphql.create_facebook_bot_campaign(
+    campaign postgraphql.facebook_bot_campaigns_type
+)
+RETURNS public.facebook_bot_campaigns
+LANGUAGE plpgsql AS $function$
+    DECLARE
+        _facebook_bot_campaign public.facebook_bot_campaigns;
+        _campaign_id integer;
+    BEGIN
+        INSERT INTO public.facebook_bot_campaigns (
+            facebook_bot_configuration_id,
+            name,
+            segment_filters,
+            total_impacted_activists,
+            created_at,
+            updated_at
+        ) VALUES (
+            campaign.facebook_bot_configuration_id,
+            campaign.name,
+            campaign.segment_filters,
+            campaign.total_impacted_activists,
+            now(),
+            now()
+        ) RETURNING * INTO _facebook_bot_campaign;
+
+        INSERT INTO public.facebook_bot_campaign_activists (
+            facebook_bot_campaign_id,
+            facebook_bot_activist_id,
+            received,
+            created_at,
+            updated_at
+        )
+            SELECT
+                (to_json(_facebook_bot_campaign) ->> 'id')::integer as facebook_bot_activist_id,
+                id as facebook_bot_activist_id,
+                FALSE,
+                NOW(),
+                NOW()
+            FROM postgraphql.get_facebook_activists_strategy(campaign.segment_filters);
+      RETURN _facebook_bot_campaign;
+    END;
+$function$;
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_bot_campaigns_by_community_id(
+    ctx_community_id integer
+)
+    RETURNS setof public.facebook_bot_campaigns
+    LANGUAGE sql
+    IMMUTABLE
+AS $function$
+    SELECT campaigns.*
+    FROM public.facebook_bot_campaigns as campaigns
+    LEFT JOIN public.facebook_bot_configurations as configs
+        ON campaigns.facebook_bot_configuration_id = configs.id
+    WHERE configs.community_id = ctx_community_id;
+$function$;
+}
+  end
+
+  def down
+    %Q{
+DROP FUNCTION postgraphql.get_facebook_bot_campaigns_by_community_id(ctx_community_id integer);
+DROP FUNCTION postgraphql.create_facebook_bot_campaign(campaign postgraphql.facebook_bot_campaigns_type)
+DROP TYPE postgraphql.facebook_bot_campaigns_type;
+REVOKE USAGE ON SEQUENCE public.facebook_bot_campaign_activists_id_seq FROM admin, common_user;
+REVOKE USAGE ON SEQUENCE public.facebook_bot_campaigns_id_seq FROM admin, common_user;
+REVOKE SELECT, INSERT, UPDATE, DELETE ON public.facebook_bot_campaign_activists FROM admin, common_user;
+REVOKE SELECT, INSERT, UPDATE, DELETE ON public.facebook_bot_campaigns FROM admin, common_user;
+}
+  end
+end

--- a/db/migrate/20171109154132_add_facebook_bot_campaign_actions_to_postgraphql.rb
+++ b/db/migrate/20171109154132_add_facebook_bot_campaign_actions_to_postgraphql.rb
@@ -75,7 +75,7 @@ $function$;
   def down
     %Q{
 DROP FUNCTION postgraphql.get_facebook_bot_campaigns_by_community_id(ctx_community_id integer);
-DROP FUNCTION postgraphql.create_facebook_bot_campaign(campaign postgraphql.facebook_bot_campaigns_type)
+DROP FUNCTION postgraphql.create_facebook_bot_campaign(campaign postgraphql.facebook_bot_campaigns_type);
 DROP TYPE postgraphql.facebook_bot_campaigns_type;
 REVOKE USAGE ON SEQUENCE public.facebook_bot_campaign_activists_id_seq FROM admin, common_user;
 REVOKE USAGE ON SEQUENCE public.facebook_bot_campaigns_id_seq FROM admin, common_user;

--- a/db/migrate/20171114132823_add_facebook_bot_campaign_segmentation_filter_functions_to_postgraphql.rb
+++ b/db/migrate/20171114132823_add_facebook_bot_campaign_segmentation_filter_functions_to_postgraphql.rb
@@ -1,0 +1,294 @@
+class AddFacebookBotCampaignSegmentationFilterFunctionsToPostgraphql < ActiveRecord::Migration
+  def up
+    execute %Q{
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_by_campaigns_exclusion(
+    segment_filters jsonb,
+    campaign_ids int[]
+)
+    RETURNS SETOF postgraphql.facebook_activist_search_result_type
+    LANGUAGE sql
+    IMMUTABLE
+AS $function$
+    SELECT
+        fas.fb_context_recipient_id,
+        fas.fb_context_sender_id,
+        fas.data,
+        fas.messages,
+        fas.quick_replies,
+        fas.created_at,
+        fas.updated_at,
+        fas.id
+    FROM postgraphql.get_facebook_activists_strategy(segment_filters) as fas
+    LEFT JOIN (
+        SELECT fba.*
+        FROM public.facebook_bot_campaign_activists as fbca
+        LEFT JOIN public.facebook_bot_activists as fba
+            ON fba.id = fbca.facebook_bot_activist_id
+        WHERE fbca.facebook_bot_campaign_id = ANY(campaign_ids)
+    ) as fbca
+        ON fbca.fb_context_recipient_id = fas.fb_context_recipient_id
+    WHERE fbca.id IS NULL
+    ORDER BY fas.updated_at DESC;
+$function$;
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_by_campaign_ids(
+    campaign_ids int[]
+)
+    RETURNS SETOF postgraphql.facebook_activist_search_result_type
+    LANGUAGE sql
+    IMMUTABLE
+AS $function$
+    SELECT
+        DISTINCT _fba.fb_context_recipient_id,
+        _fba.fb_context_sender_id,
+        _fba.data,
+        _fba.messages,
+        _fba.quick_replies,
+        _fba.created_at,
+        _fba.updated_at,
+        _fba.id
+    FROM public.facebook_bot_campaign_activists as _fbca
+    LEFT JOIN public.facebook_bot_activists as _fba
+        ON _fba.id = _fbca.facebook_bot_activist_id
+    WHERE _fbca.facebook_bot_campaign_id = ANY(campaign_ids)
+$function$;
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_by_campaigns_inclusion(
+    segment_filters jsonb,
+    campaign_ids int[]
+)
+    RETURNS SETOF postgraphql.facebook_activist_search_result_type
+    LANGUAGE sql
+    IMMUTABLE
+AS $function$
+    SELECT
+        fas.fb_context_recipient_id,
+        fas.fb_context_sender_id,
+        fas.data,
+        fas.messages,
+        fas.quick_replies,
+        fas.created_at,
+        fas.updated_at,
+        fas.id
+    FROM postgraphql.get_facebook_activists_strategy(segment_filters) as fas
+    UNION
+    SELECT *
+    FROM postgraphql.get_facebook_activists_by_campaign_ids(campaign_ids);
+$function$;
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_by_campaigns_both_inclusion_exclusion(
+    segment_filters jsonb,
+    campaign_exclusion_ids int[],
+    campaign_inclusion_ids int[]
+)
+    RETURNS SETOF postgraphql.facebook_activist_search_result_type
+    LANGUAGE sql
+    IMMUTABLE
+AS $function$
+    SELECT *
+    FROM postgraphql.get_facebook_activists_by_campaigns_exclusion(
+        segment_filters,
+        campaign_exclusion_ids
+    )
+    UNION
+    SELECT *
+    FROM postgraphql.get_facebook_activists_by_campaign_ids(
+        campaign_inclusion_ids
+    );
+$function$;
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_strategy(search jsonb)
+RETURNS setof postgraphql.facebook_activist_search_result_type
+LANGUAGE plpgsql
+IMMUTABLE
+AS $function$
+    DECLARE
+        _message                text      := search ->> 'message';
+        _quick_reply            text      := search ->> 'quickReply';
+        _date_interval_start    timestamp := search ->> 'dateIntervalStart';
+        _date_interval_end      timestamp := search ->> 'dateIntervalEnd';
+        _campaign_exclusion_ids int[]     := search ->> 'campaignExclusionIds';
+        _campaign_inclusion_ids int[]     := search ->> 'campaignInclusionIds';
+
+        _m      boolean := _message                IS NOT NULL;
+        _qr     boolean := _quick_reply            IS NOT NULL;
+        _start  boolean := _date_interval_start    IS NOT NULL;
+        _end    boolean := _date_interval_end      IS NOT NULL;
+        _ce     boolean := _campaign_exclusion_ids IS NOT NULL;
+        _ci     boolean := _campaign_inclusion_ids IS NOT NULL;
+
+        _is_only_campaign_exclusion boolean :=      _ce  AND (NOT _ci);
+        _is_only_campaign_inclusion boolean := (NOT _ce) AND      _ci;
+        _is_both_campaign_strategy  boolean :=      _ce  AND      _ci;
+        _is_only_message            boolean :=      _m  AND (NOT _qr) AND (NOT _start) AND (NOT _end);
+        _is_only_q_reply            boolean := (NOT _m) AND      _qr  AND (NOT _start) AND (NOT _end);
+        _is_only_date_interval      boolean := (NOT _m) AND (NOT _qr) AND      _start  AND      _end;
+        _is_q_reply_date_interval   boolean := (NOT _m) AND      _qr  AND       _start AND      _end;
+        _is_message_date_interval   boolean :=      _m  AND (NOT _qr) AND      _start  AND      _end;
+        _is_message_q_reply         boolean :=      _m  AND      _qr  AND (NOT _start) AND (NOT _end);
+        _is_all                     boolean :=      _m  AND      _qr  AND      _start  AND      _end;
+    BEGIN
+        IF _is_only_campaign_exclusion THEN RETURN QUERY (
+            SELECT *
+            FROM postgraphql.get_facebook_activists_by_campaigns_exclusion(
+                search - 'campaignExclusionIds',
+                _campaign_exclusion_ids
+            )
+        );
+        ELSIF _is_only_campaign_inclusion THEN RETURN QUERY (
+            SELECT *
+            FROM postgraphql.get_facebook_activists_by_campaigns_inclusion(
+                search - 'campaignInclusionIds',
+                _campaign_inclusion_ids
+            )
+        );
+        ELSIF _is_both_campaign_strategy THEN RETURN QUERY (
+            SELECT *
+            FROM postgraphql.get_facebook_activists_by_campaigns_both_inclusion_exclusion(
+                search - 'campaignInclusionIds' - 'campaignExclusionIds',
+                _campaign_exclusion_ids,
+                _campaign_inclusion_ids
+            )
+        );
+        ELSE
+            IF _is_only_message THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_message(_message)
+            );
+            ELSIF _is_only_q_reply THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_quick_reply(_quick_reply)
+            );
+            ELSIF _is_only_date_interval THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_date_interval(
+                    _date_interval_start,
+                    _date_interval_end
+                )
+            );
+            ELSIF _is_q_reply_date_interval THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_quick_reply_date_interval(
+                    _quick_reply,
+                    _date_interval_start,
+                    _date_interval_end
+                )
+            );
+            ELSIF _is_message_date_interval THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_message_date_interval(
+                    _message,
+                    _date_interval_start,
+                    _date_interval_end
+                )
+            );
+            ELSIF _is_message_q_reply THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_message_quick_reply(
+                    _message,
+                    _quick_reply
+                )
+            );
+            ELSIF _is_all THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_message_quick_reply_date_interval(
+                    _message,
+                    _quick_reply,
+                    _date_interval_start,
+                    _date_interval_end
+                )
+            );
+            END IF;
+        END IF;
+    END;
+$function$;
+}
+  end
+
+  def down
+    execute %Q{
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_strategy(search jsonb)
+RETURNS setof postgraphql.facebook_activist_search_result_type
+LANGUAGE plpgsql
+IMMUTABLE
+AS $function$
+    DECLARE
+        _message text := search ->> 'message';
+        _quickReply text := search ->> 'quickReply';
+        _dateIntervalStart timestamp := search ->> 'dateIntervalStart';
+        _dateIntervalEnd timestamp := search ->> 'dateIntervalEnd';
+        _m boolean := _message IS NOT NULL;
+        _qr boolean := _quickReply IS NOT NULL;
+        _start boolean := _dateIntervalStart IS NOT NULL;
+        _end boolean := _dateIntervalEnd IS NOT NULL;
+        _is_only_message boolean :=               _m  AND (NOT _qr) AND (NOT _start) AND (NOT _end);
+        _is_only_q_reply boolean :=          (NOT _m) AND      _qr  AND (NOT _start) AND (NOT _end);
+        _is_only_date_interval boolean :=    (NOT _m) AND (NOT _qr) AND      _start  AND      _end;
+        _is_q_reply_date_interval boolean := (NOT _m) AND      _qr  AND       _start AND      _end;
+        _is_message_date_interval boolean :=      _m  AND (NOT _qr) AND      _start  AND      _end;
+        _is_message_q_reply boolean :=            _m  AND      _qr  AND (NOT _start) AND (NOT _end);
+        _is_all boolean :=                        _m  AND      _qr  AND      _start  AND      _end;
+    BEGIN
+        IF _is_only_message THEN RETURN QUERY (
+            SELECT * FROM postgraphql.get_facebook_activists_by_message(_message)
+        );
+        ELSIF _is_only_q_reply THEN RETURN QUERY (
+            SELECT * FROM postgraphql.get_facebook_activists_by_quick_reply(_quickReply)
+        );
+        ELSIF _is_only_date_interval THEN RETURN QUERY (
+            SELECT * FROM postgraphql.get_facebook_activists_by_date_interval(
+                _dateIntervalStart,
+                _dateIntervalEnd
+            )
+        );
+        ELSIF _is_q_reply_date_interval THEN RETURN QUERY (
+            SELECT * FROM postgraphql.get_facebook_activists_by_quick_reply_date_interval(
+                _quickReply,
+                _dateIntervalStart,
+                _dateIntervalEnd
+            )
+        );
+        ELSIF _is_message_date_interval THEN RETURN QUERY (
+            SELECT * FROM postgraphql.get_facebook_activists_by_message_date_interval(
+                _message,
+                _dateIntervalStart,
+                _dateIntervalEnd
+            )
+        );
+        ELSIF _is_message_q_reply THEN RETURN QUERY (
+            SELECT * FROM postgraphql.get_facebook_activists_by_message_quick_reply(
+                _message,
+                _quickReply
+            )
+        );
+        ELSIF _is_all THEN RETURN QUERY (
+            SELECT * FROM postgraphql.get_facebook_activists_by_message_quick_reply_date_interval(
+                _message,
+                _quickReply,
+                _dateIntervalStart,
+                _dateIntervalEnd
+            )
+        );
+        END IF;
+    END;
+$function$;
+
+DROP FUNCTION postgraphql.get_facebook_activists_by_campaigns_both_inclusion_exclusion(
+    segment_filters jsonb,
+    campaign_exclusion_ids int[],
+    campaign_inclusion_ids int[]
+);
+DROP FUNCTION postgraphql.get_facebook_activists_by_campaigns_inclusion(
+    segment_filters jsonb,
+    campaign_ids int[]
+);
+DROP FUNCTION postgraphql.get_facebook_activists_by_campaign_ids(
+  campaign_ids int[]
+);
+DROP FUNCTION postgraphql.get_facebook_activists_by_campaigns_exclusion(
+    segment_filters jsonb,
+    campaign_ids int[]
+);
+}
+  end
+end

--- a/db/migrate/20171114202010_add_facebook_bot_campaign_activists_actions_to_postgraphql.rb
+++ b/db/migrate/20171114202010_add_facebook_bot_campaign_activists_actions_to_postgraphql.rb
@@ -1,0 +1,77 @@
+class AddFacebookBotCampaignActivistsActionsToPostgraphql < ActiveRecord::Migration
+  def up
+    execute %Q{
+CREATE TYPE postgraphql.get_facebook_bot_campaign_activists_by_campaign_type AS (
+    id integer,
+    facebook_bot_campaign_id integer,
+    facebook_bot_activist_id integer,
+    received boolean,
+    "log" jsonb,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone,
+    fb_context_recipient_id text,
+    fb_context_sender_id text,
+    data jsonb,
+    messages tsvector,
+    quick_replies text[],
+    interaction_dates timestamp without time zone[]
+);
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_bot_campaign_activists_by_campaign_id (
+    campaign_id INTEGER
+)
+    RETURNS SETOF postgraphql.get_facebook_bot_campaign_activists_by_campaign_type
+    LANGUAGE sql
+    IMMUTABLE
+AS $function$
+    SELECT
+        fbca.*,
+        fba.fb_context_recipient_id,
+        fba.fb_context_sender_id,
+        fba.data,
+        fba.messages,
+        fba.quick_replies,
+        fba.interaction_dates
+    FROM public.facebook_bot_campaign_activists as fbca
+    LEFT JOIN public.facebook_bot_activists as fba
+        ON fba.id = fbca.facebook_bot_activist_id
+    WHERE fbca.facebook_bot_campaign_id = campaign_id;
+$function$;
+
+CREATE OR REPLACE FUNCTION postgraphql.update_facebook_bot_campaign_activists(
+    facebook_bot_campaign_activist_id integer,
+    ctx_received boolean,
+    ctx_log jsonb
+)
+    RETURNS public.facebook_bot_campaign_activists
+    LANGUAGE plpgsql
+AS $function$
+    DECLARE
+        v_facebook_bot_campaign_activist public.facebook_bot_campaign_activists;
+    BEGIN
+        UPDATE public.facebook_bot_campaign_activists SET
+            received = ctx_received,
+            "log" = ctx_log,
+            updated_at = NOW()
+        WHERE id = facebook_bot_campaign_activist_id
+        RETURNING * INTO v_facebook_bot_campaign_activist;
+        RETURN v_facebook_bot_campaign_activist;
+    END;
+$function$;
+}
+  end
+
+  def down
+    execute %Q{
+DROP FUNCTION postgraphql.update_facebook_bot_campaign_activists(
+    facebook_bot_campaign_activist_id integer,
+    ctx_received boolean,
+    ctx_log jsonb
+);
+DROP FUNCTION postgraphql.get_facebook_bot_campaign_activists_by_campaign_id (
+    campaign_id INTEGER
+);
+DROP TYPE postgraphql.get_facebook_bot_campaign_activists_by_campaign_type;
+}
+  end
+end

--- a/db/migrate/20171114210433_rename_facebook_bot_activists_strategy_function.rb
+++ b/db/migrate/20171114210433_rename_facebook_bot_activists_strategy_function.rb
@@ -1,0 +1,417 @@
+class RenameFacebookBotActivistsStrategyFunction < ActiveRecord::Migration
+  def up
+    execute %Q{
+DROP FUNCTION postgraphql.get_facebook_activists_strategy(search jsonb);
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_bot_activists_strategy(search jsonb)
+RETURNS setof postgraphql.facebook_activist_search_result_type
+LANGUAGE plpgsql
+IMMUTABLE
+AS $function$
+    DECLARE
+        _message                text      := search ->> 'message';
+        _quick_reply            text      := search ->> 'quickReply';
+        _date_interval_start    timestamp := search ->> 'dateIntervalStart';
+        _date_interval_end      timestamp := search ->> 'dateIntervalEnd';
+        _campaign_exclusion_ids int[]     := search ->> 'campaignExclusionIds';
+        _campaign_inclusion_ids int[]     := search ->> 'campaignInclusionIds';
+
+        _m      boolean := _message                IS NOT NULL;
+        _qr     boolean := _quick_reply            IS NOT NULL;
+        _start  boolean := _date_interval_start    IS NOT NULL;
+        _end    boolean := _date_interval_end      IS NOT NULL;
+        _ce     boolean := _campaign_exclusion_ids IS NOT NULL;
+        _ci     boolean := _campaign_inclusion_ids IS NOT NULL;
+
+        _is_only_campaign_exclusion boolean :=      _ce  AND (NOT _ci);
+        _is_only_campaign_inclusion boolean := (NOT _ce) AND      _ci;
+        _is_both_campaign_strategy  boolean :=      _ce  AND      _ci;
+        _is_only_message            boolean :=      _m  AND (NOT _qr) AND (NOT _start) AND (NOT _end);
+        _is_only_q_reply            boolean := (NOT _m) AND      _qr  AND (NOT _start) AND (NOT _end);
+        _is_only_date_interval      boolean := (NOT _m) AND (NOT _qr) AND      _start  AND      _end;
+        _is_q_reply_date_interval   boolean := (NOT _m) AND      _qr  AND       _start AND      _end;
+        _is_message_date_interval   boolean :=      _m  AND (NOT _qr) AND      _start  AND      _end;
+        _is_message_q_reply         boolean :=      _m  AND      _qr  AND (NOT _start) AND (NOT _end);
+        _is_all                     boolean :=      _m  AND      _qr  AND      _start  AND      _end;
+    BEGIN
+        IF _is_only_campaign_exclusion THEN RETURN QUERY (
+            SELECT *
+            FROM postgraphql.get_facebook_activists_by_campaigns_exclusion(
+                search - 'campaignExclusionIds',
+                _campaign_exclusion_ids
+            )
+        );
+        ELSIF _is_only_campaign_inclusion THEN RETURN QUERY (
+            SELECT *
+            FROM postgraphql.get_facebook_activists_by_campaigns_inclusion(
+                search - 'campaignInclusionIds',
+                _campaign_inclusion_ids
+            )
+        );
+        ELSIF _is_both_campaign_strategy THEN RETURN QUERY (
+            SELECT *
+            FROM postgraphql.get_facebook_activists_by_campaigns_both_inclusion_exclusion(
+                search - 'campaignInclusionIds' - 'campaignExclusionIds',
+                _campaign_exclusion_ids,
+                _campaign_inclusion_ids
+            )
+        );
+        ELSE
+            IF _is_only_message THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_message(_message)
+            );
+            ELSIF _is_only_q_reply THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_quick_reply(_quick_reply)
+            );
+            ELSIF _is_only_date_interval THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_date_interval(
+                    _date_interval_start,
+                    _date_interval_end
+                )
+            );
+            ELSIF _is_q_reply_date_interval THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_quick_reply_date_interval(
+                    _quick_reply,
+                    _date_interval_start,
+                    _date_interval_end
+                )
+            );
+            ELSIF _is_message_date_interval THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_message_date_interval(
+                    _message,
+                    _date_interval_start,
+                    _date_interval_end
+                )
+            );
+            ELSIF _is_message_q_reply THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_message_quick_reply(
+                    _message,
+                    _quick_reply
+                )
+            );
+            ELSIF _is_all THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_message_quick_reply_date_interval(
+                    _message,
+                    _quick_reply,
+                    _date_interval_start,
+                    _date_interval_end
+                )
+            );
+            END IF;
+        END IF;
+    END;
+$function$;
+
+CREATE OR REPLACE FUNCTION postgraphql.create_facebook_bot_campaign(
+    campaign postgraphql.facebook_bot_campaigns_type
+)
+RETURNS public.facebook_bot_campaigns
+LANGUAGE plpgsql AS $function$
+    DECLARE
+        _facebook_bot_campaign public.facebook_bot_campaigns;
+        _campaign_id integer;
+    BEGIN
+        INSERT INTO public.facebook_bot_campaigns (
+            facebook_bot_configuration_id,
+            name,
+            segment_filters,
+            total_impacted_activists,
+            created_at,
+            updated_at
+        ) VALUES (
+            campaign.facebook_bot_configuration_id,
+            campaign.name,
+            campaign.segment_filters,
+            campaign.total_impacted_activists,
+            now(),
+            now()
+        ) RETURNING * INTO _facebook_bot_campaign;
+
+        INSERT INTO public.facebook_bot_campaign_activists (
+            facebook_bot_campaign_id,
+            facebook_bot_activist_id,
+            received,
+            created_at,
+            updated_at
+        )
+            SELECT
+                (to_json(_facebook_bot_campaign) ->> 'id')::integer as facebook_bot_activist_id,
+                id as facebook_bot_activist_id,
+                FALSE,
+                NOW(),
+                NOW()
+            FROM postgraphql.get_facebook_bot_activists_strategy(campaign.segment_filters);
+      RETURN _facebook_bot_campaign;
+    END;
+$function$;
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_by_campaigns_exclusion(
+    segment_filters jsonb,
+    campaign_ids int[]
+)
+    RETURNS SETOF postgraphql.facebook_activist_search_result_type
+    LANGUAGE sql
+    IMMUTABLE
+AS $function$
+    SELECT
+        fas.fb_context_recipient_id,
+        fas.fb_context_sender_id,
+        fas.data,
+        fas.messages,
+        fas.quick_replies,
+        fas.created_at,
+        fas.updated_at,
+        fas.id
+    FROM postgraphql.get_facebook_bot_activists_strategy(segment_filters) as fas
+    LEFT JOIN (
+        SELECT fba.*
+        FROM public.facebook_bot_campaign_activists as fbca
+        LEFT JOIN public.facebook_bot_activists as fba
+            ON fba.id = fbca.facebook_bot_activist_id
+        WHERE fbca.facebook_bot_campaign_id = ANY(campaign_ids)
+    ) as fbca
+        ON fbca.fb_context_recipient_id = fas.fb_context_recipient_id
+    WHERE fbca.id IS NULL
+    ORDER BY fas.updated_at DESC;
+$function$;
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_by_campaigns_inclusion(
+    segment_filters jsonb,
+    campaign_ids int[]
+)
+    RETURNS SETOF postgraphql.facebook_activist_search_result_type
+    LANGUAGE sql
+    IMMUTABLE
+AS $function$
+    SELECT
+        fas.fb_context_recipient_id,
+        fas.fb_context_sender_id,
+        fas.data,
+        fas.messages,
+        fas.quick_replies,
+        fas.created_at,
+        fas.updated_at,
+        fas.id
+    FROM postgraphql.get_facebook_bot_activists_strategy(segment_filters) as fas
+    UNION
+    SELECT *
+    FROM postgraphql.get_facebook_activists_by_campaign_ids(campaign_ids);
+$function$;
+}
+  end
+
+  def down
+    execute %Q{
+DROP FUNCTION postgraphql.get_facebook_bot_activists_strategy(search jsonb);
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_strategy(search jsonb)
+RETURNS setof postgraphql.facebook_activist_search_result_type
+LANGUAGE plpgsql
+IMMUTABLE
+AS $function$
+    DECLARE
+        _message                text      := search ->> 'message';
+        _quick_reply            text      := search ->> 'quickReply';
+        _date_interval_start    timestamp := search ->> 'dateIntervalStart';
+        _date_interval_end      timestamp := search ->> 'dateIntervalEnd';
+        _campaign_exclusion_ids int[]     := search ->> 'campaignExclusionIds';
+        _campaign_inclusion_ids int[]     := search ->> 'campaignInclusionIds';
+
+        _m      boolean := _message                IS NOT NULL;
+        _qr     boolean := _quick_reply            IS NOT NULL;
+        _start  boolean := _date_interval_start    IS NOT NULL;
+        _end    boolean := _date_interval_end      IS NOT NULL;
+        _ce     boolean := _campaign_exclusion_ids IS NOT NULL;
+        _ci     boolean := _campaign_inclusion_ids IS NOT NULL;
+
+        _is_only_campaign_exclusion boolean :=      _ce  AND (NOT _ci);
+        _is_only_campaign_inclusion boolean := (NOT _ce) AND      _ci;
+        _is_both_campaign_strategy  boolean :=      _ce  AND      _ci;
+        _is_only_message            boolean :=      _m  AND (NOT _qr) AND (NOT _start) AND (NOT _end);
+        _is_only_q_reply            boolean := (NOT _m) AND      _qr  AND (NOT _start) AND (NOT _end);
+        _is_only_date_interval      boolean := (NOT _m) AND (NOT _qr) AND      _start  AND      _end;
+        _is_q_reply_date_interval   boolean := (NOT _m) AND      _qr  AND       _start AND      _end;
+        _is_message_date_interval   boolean :=      _m  AND (NOT _qr) AND      _start  AND      _end;
+        _is_message_q_reply         boolean :=      _m  AND      _qr  AND (NOT _start) AND (NOT _end);
+        _is_all                     boolean :=      _m  AND      _qr  AND      _start  AND      _end;
+    BEGIN
+        IF _is_only_campaign_exclusion THEN RETURN QUERY (
+            SELECT *
+            FROM postgraphql.get_facebook_activists_by_campaigns_exclusion(
+                search - 'campaignExclusionIds',
+                _campaign_exclusion_ids
+            )
+        );
+        ELSIF _is_only_campaign_inclusion THEN RETURN QUERY (
+            SELECT *
+            FROM postgraphql.get_facebook_activists_by_campaigns_inclusion(
+                search - 'campaignInclusionIds',
+                _campaign_inclusion_ids
+            )
+        );
+        ELSIF _is_both_campaign_strategy THEN RETURN QUERY (
+            SELECT *
+            FROM postgraphql.get_facebook_activists_by_campaigns_both_inclusion_exclusion(
+                search - 'campaignInclusionIds' - 'campaignExclusionIds',
+                _campaign_exclusion_ids,
+                _campaign_inclusion_ids
+            )
+        );
+        ELSE
+            IF _is_only_message THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_message(_message)
+            );
+            ELSIF _is_only_q_reply THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_quick_reply(_quick_reply)
+            );
+            ELSIF _is_only_date_interval THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_date_interval(
+                    _date_interval_start,
+                    _date_interval_end
+                )
+            );
+            ELSIF _is_q_reply_date_interval THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_quick_reply_date_interval(
+                    _quick_reply,
+                    _date_interval_start,
+                    _date_interval_end
+                )
+            );
+            ELSIF _is_message_date_interval THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_message_date_interval(
+                    _message,
+                    _date_interval_start,
+                    _date_interval_end
+                )
+            );
+            ELSIF _is_message_q_reply THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_message_quick_reply(
+                    _message,
+                    _quick_reply
+                )
+            );
+            ELSIF _is_all THEN RETURN QUERY (
+                SELECT *
+                FROM postgraphql.get_facebook_activists_by_message_quick_reply_date_interval(
+                    _message,
+                    _quick_reply,
+                    _date_interval_start,
+                    _date_interval_end
+                )
+            );
+            END IF;
+        END IF;
+    END;
+$function$;
+
+CREATE OR REPLACE FUNCTION postgraphql.create_facebook_bot_campaign(
+    campaign postgraphql.facebook_bot_campaigns_type
+)
+RETURNS public.facebook_bot_campaigns
+LANGUAGE plpgsql AS $function$
+    DECLARE
+        _facebook_bot_campaign public.facebook_bot_campaigns;
+        _campaign_id integer;
+    BEGIN
+        INSERT INTO public.facebook_bot_campaigns (
+            facebook_bot_configuration_id,
+            name,
+            segment_filters,
+            total_impacted_activists,
+            created_at,
+            updated_at
+        ) VALUES (
+            campaign.facebook_bot_configuration_id,
+            campaign.name,
+            campaign.segment_filters,
+            campaign.total_impacted_activists,
+            now(),
+            now()
+        ) RETURNING * INTO _facebook_bot_campaign;
+
+        INSERT INTO public.facebook_bot_campaign_activists (
+            facebook_bot_campaign_id,
+            facebook_bot_activist_id,
+            received,
+            created_at,
+            updated_at
+        )
+            SELECT
+                (to_json(_facebook_bot_campaign) ->> 'id')::integer as facebook_bot_activist_id,
+                id as facebook_bot_activist_id,
+                FALSE,
+                NOW(),
+                NOW()
+            FROM postgraphql.get_facebook_activists_strategy(campaign.segment_filters);
+      RETURN _facebook_bot_campaign;
+    END;
+$function$;
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_by_campaigns_exclusion(
+    segment_filters jsonb,
+    campaign_ids int[]
+)
+    RETURNS SETOF postgraphql.facebook_activist_search_result_type
+    LANGUAGE sql
+    IMMUTABLE
+AS $function$
+    SELECT
+        fas.fb_context_recipient_id,
+        fas.fb_context_sender_id,
+        fas.data,
+        fas.messages,
+        fas.quick_replies,
+        fas.created_at,
+        fas.updated_at,
+        fas.id
+    FROM postgraphql.get_facebook_activists_strategy(segment_filters) as fas
+    LEFT JOIN (
+        SELECT fba.*
+        FROM public.facebook_bot_campaign_activists as fbca
+        LEFT JOIN public.facebook_bot_activists as fba
+            ON fba.id = fbca.facebook_bot_activist_id
+        WHERE fbca.facebook_bot_campaign_id = ANY(campaign_ids)
+    ) as fbca
+        ON fbca.fb_context_recipient_id = fas.fb_context_recipient_id
+    WHERE fbca.id IS NULL
+    ORDER BY fas.updated_at DESC;
+$function$;
+
+CREATE OR REPLACE FUNCTION postgraphql.get_facebook_activists_by_campaigns_inclusion(
+    segment_filters jsonb,
+    campaign_ids int[]
+)
+    RETURNS SETOF postgraphql.facebook_activist_search_result_type
+    LANGUAGE sql
+    IMMUTABLE
+AS $function$
+    SELECT
+        fas.fb_context_recipient_id,
+        fas.fb_context_sender_id,
+        fas.data,
+        fas.messages,
+        fas.quick_replies,
+        fas.created_at,
+        fas.updated_at,
+        fas.id
+    FROM postgraphql.get_facebook_activists_strategy(segment_filters) as fas
+    UNION
+    SELECT *
+    FROM postgraphql.get_facebook_activists_by_campaign_ids(campaign_ids);
+$function$;
+}
+  end
+end


### PR DESCRIPTION
# Related issues
- Save bot mass message campaign #381

# How to test
Lista de testes

## `create_facebook_bot_campaign`
A papel desta function é criar um novo registro em `public.facebook_bot_campaigns` e um novo registro para cada ativista que retornar na busca com os filtros do atributo `segment_filters` em `public.facebook_bot_campaign_activists`.

- Query efetuada usando GraphQL
```graphql
mutation createFacebookBotCampaign(
  $facebookBotConfigurationId: Int!
  $name: String!
  $segmentFilters: Json!
  $totalImpactedActivists: Int!
) {
  createFacebookBotCampaign(input: {
    campaign: {
      facebookBotConfigurationId: $facebookBotConfigurationId,
      name: $name,
      segmentFilters: $segmentFilters,
      totalImpactedActivists: $totalImpactedActivists
    }
  }) {
    facebookBotCampaigns {
      id
      facebookBotConfigurationId
      name
      segmentFilters
      totalImpactedActivists
      createdAt
      updatedAt
    }
  }
}
```
**Query Variables**
```json
{
  "facebookBotConfigurationId": 1,
  "name": "First Campaign",
  "segmentFilters": "{ \"message\": \"oi beta\", \"quickReply\": \"QUICK_REPLY_G\", \"dateIntervalStart\": \"2017-09-01\", \"dateIntervalEnd\": \"2017-09-02\" }",
  "totalImpactedActivists": 48
}
```

- Verifique se o registro da campanha foi cadastrado corretamente com a query abaixo:
```sql
SELECT * FROM public.facebook_bot_campaigns;
```

- Verifica que os registros de ativistas impactados foram cadastrados corretamente com a query abaixo:
```sql
SELECT * FROM public.facebook_bot_campaign_activists;
```


## `get_facebook_bot_campaigns_by_community_id`
O papel desta function é retornar a lista de campanhas de uma determinada comunidade.

- Verifique qual comunidade possui uma configuração de bot cadastrada:
```sql
SELECT * FROM public.facebook_bot_configurations;
```

- Pegue o valor do campo `community_id` da query anterior, e verifique se as campanhas cadastradas para os bots daquela comunidade estão corretos, utilizando a query abaixo:

**SQL**
```sql
SELECT * FROM postgraphql.get_facebook_bot_campaigns_by_community_id(73);
```

**GraphQL**
```graphql
query fetchFacebookBotCampaignsByCommunityId($communityId: Int!) {
  query: getFacebookBotCampaignsByCommunityId(ctxCommunityId: $communityId) {
    campaigns: nodes {
      id
      facebookBotConfigurationId
      name
      segmentFilters
      totalImpactedActivists
      createdAt
      updatedAt
    }
  }
}
```
**Query Variables**
```json
{
  "communityId": 73
}
```

# Geração de massa de teste
Para que seja possível a execução dos testes de cada função de segmentação de ativistas por campanha, é necessário que a query abaixo seja executada no banco de dados:

```sql
-- 
-- Inserir massa de dados de usuários e interações
-- 
INSERT INTO "public"."activist_facebook_bot_interactions"("activist_id","facebook_bot_configuration_id","fb_context_recipient_id","fb_context_sender_id","interaction","created_at","updated_at")
VALUES
-- Z
(NULL,1,E'1732013863493543',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124214"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493544',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124214"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493545',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124214"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493546',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124214"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493547',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124214"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493548',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124214"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493549',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124214"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493550',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124214"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493551',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124214"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493552',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124214"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),

-- X
(NULL,1,E'1732013863493543',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124221"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493544',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124221"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493545',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124221"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493553',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124221"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493554',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124221"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),

-- Y
(NULL,1,E'1732013863493543',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124225"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493547',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124225"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493548',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124225"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493549',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124225"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493554',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124225"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493555',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124225"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),

-- W
(NULL,1,E'1732013863493556',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124230"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493557',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124230"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493558',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124230"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493559',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124230"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493560',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124230"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493561',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124230"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493562',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124230"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493563',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124230"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493564',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124230"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493565',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124230"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493566',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124230"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493567',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124230"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493568',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124230"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234'),
(NULL,1,E'1732013863493569',E'130099484248245',E'{"payload": {"sender": {"id": "1732013863493543"}, "message": {"mid": "mid.$cAAAsoGMJv1Vl6c0_e1fuIf3M9j4k", "seq": 61019, "text": "20171114124230"}, "recipient": {"id": "130099484248245"}, "timestamp": 1510629439355}, "profile": {"id": "1732013863493543", "gender": "male", "locale": "pt_BR", "timezone": -2, "last_name": "Takeda", "first_name": "Gabriel", "profile_pic": "https://scontent.xx.fbcdn.net/v/t31.0-1/19250447_1680559175317618_6725395899405980837_o.jpg?oh=03b30fc73a81e7681f00c40ddc5822fa&oe=5A9C27D9"}}',E'2017-11-14 03:17:23.746234',E'2017-11-14 03:17:23.746234');
```

Na própria query acima, é possível ver uma breve separação dos dados em `Z`, `X`, `Y` e `W`... Essa separação corresponde aos círculos representados no gráfico de intersecção apresentado [neste comentário](https://github.com/nossas/bonde-server/pull/394#issuecomment-343245332)... Os dados de `W` não foram representados no gráfico mas, ele representa um novo círculo.

# Criar campanhas para teste de segmentação
Neste passo é necessário que sejam criadas as campanhas que serão utilizadas nos testes em seguida. Para isso, utilize a mesma GraphQL mutation `createFacebookBotCampaign` citada anteriormente, com suas respectivas **Query Variables**:

- **Campanha `X`**
```json
// # X
// X ∩ Z ∩ Y = 1
// X ∩ Z = 2
// X ∩ Y = 1
// Z - (Z ∩ X) = 7
// Z ∪ X = 12
{
  "facebookBotConfigurationId": 1,
  "name": "20171114124221 Campaign",
  "segmentFilters": "{ \"message\": \"20171114124221\" }",
  "totalImpactedActivists": 5
}
```

- **Campanha `Y`**
```json
// # Y
// Y ∩ Z ∩ X = 1
// Y ∩ Z = 3
// Y ∩ X = 1
// Z - (Z ∩ Y) = 6
// Z ∪ Y = 12
{
  "facebookBotConfigurationId": 1,
  "name": "20171114124225 Campaign",
  "segmentFilters": "{ \"message\": \"20171114124225\" }",
  "totalImpactedActivists": 6
}
```

- **Campanha `W`**
```json
// # W
// W ∩ Z ∩ X ∩ Y = 0
// W ∩ Z ∩ X = 0
// W ∩ Z ∩ Y = 0
// W ∩ Z = 0
// W ∩ X = 0
// W ∩ Y = 0
// Z - (Z ∩ W) = 10
// Z ∪ W = 24
// Z - (Z ∩ X) - (Z ∩ Y) + (Z ∪ W) = 18
// Z - (Z ∩ X) + (Z ∪ W) = 21
{
  "facebookBotConfigurationId": 1,
  "name": "20171114124230 Campaign",
  "segmentFilters": "{ \"message\": \"20171114124230\" }",
  "totalImpactedActivists": 14
}
```

**Observação:** Note que em cada Query Variable, possui alguns comentários que representam alguns resultados esperados que mais pra frente iremos abordar... Abaixo seguem alguns outros resultados esperados utilizando a massa de dados inserida anteriormente:
```json
// # Global expected values
// Z - (Z ∩ X) = 7
// Z - (Z ∩ Y) = 6
// Z - (Z ∩ W) = 10
// Z - (Z ∩ X) - (Z ∩ Y) = 4
// (Z - (Z ∩ X) - (Z ∩ Y)) ∪ (Z ∪ W) = 18
// Z ∪ X ∪ Y = 13
```

# Novas funções de segmentação
Nesta feature, foram inseridas 3 novas funções de segmentação:
- `get_facebook_activists_by_campaigns_exclusion`
- `get_facebook_activists_by_campaigns_inclusion`
- `get_facebook_activists_by_campaigns_both_inclusion_exclusion`

Para darmos início aos nossos testes de segmentação, execute a query abaixo para pegar o `id` das campanhas que usaremos posteriormente:
```sql
SELECT *
FROM (SELECT * FROM public.facebook_bot_campaigns ORDER BY id DESC LIMIT 3) a
ORDER BY id ASC;
```
Copie a coluna `id` das 3 linhas obtidas e guarde em um local fácil de acessar pois, usaremos nos testes.

**Exemplo de resultado:**
<img width="1211" alt="screen shot 2017-11-14 at 14 08 32" src="https://user-images.githubusercontent.com/5435389/32790363-5fe43192-c945-11e7-9bf3-cba0869fa6bd.png">
Em ordem crescente, os `id`s serão respectivamente das campanhas `X`, `Y` e `W`. Ou seja:
- **`ID_CAMPANHA_X` = 45**
- **`ID_CAMPANHA_Y` = 46**
- **`ID_CAMPANHA_W` = 47**

## `get_facebook_activists_by_campaigns_exclusion`
O papel desta function é fazer o filtro de exclusão dos ativistas impactados pelas campanhas selecionadas do grupo de ativistas selecionados via filtros básicos. Execute a query abaixo:

```sql
SELECT * FROM postgraphql.get_facebook_activists_by_campaigns_exclusion(
    '{ "message": "20171114124214" }',
    ARRAY[ID_CAMPANHA_X, ID_CAMPANHA_Y]
);
```
- O resultado esperado neste caso é: **4**
```
Z = 10
Z ∩ X = 2
Z ∩ Y = 3
Z ∩ X ∩ Y = 1
Z - (Z ∩ X) - (Z ∩ Y) - (Z ∩ X ∩ Y) = 4
```

## `get_facebook_activists_by_campaigns_inclusion`
O papel desta function é fazer o filtro de união dos ativistas impactados pelas campanhas selecionadas com grupo de ativistas selecionados via filtros básicos. Execute a query abaixo:

```sql
SELECT * FROM postgraphql.get_facebook_activists_by_campaigns_inclusion(
    '{ "message": "20171114124214" }',
    ARRAY[ID_CAMPANHA_X, ID_CAMPANHA_Y]
);
```
- O resultado esperado neste caso é: **13**
```
Z = 10
X = 5
Y = 6
Z ∩ X ∩ Y = 1
Z ∩ X = 2
Z ∩ Y = 3
X ∩ Y = 1

f(Z) = Z - (Z ∩ X ∩ Y) - (Z ∩ X) - (Z ∩ Y)
     = 10 - 1 - 2 - 3
     = 4

f(X) = X - (Z ∩ X ∩ Y) - (Z ∩ X = 2) - (X ∩ Y)
     = 5 - 1 - 2 - 1
     = 1

f(Y) = Y - (Z ∩ X ∩ Y) - (Z ∩ Y) - (X ∩ Y)
     = 6 - 1 - 3 - 1
     = 1

Z ∪ X ∪ Y = f(Z) + f(X) + f(Y) + (Z ∩ X ∩ Y) + (Z ∩ X) + (Z ∩ Y) + (X ∩ Y)
          = 4 + 1 + 1 + 1 + 2 + 3 + 1
          = 13
```

### `get_facebook_activists_by_campaigns_both_inclusion_exclusion`
O papel desta function é fazer o filtro de união dos ativistas impactados pelas campanhas selecionadas + grupo de ativistas selecionados via filtros básicos + grupo de ativistas que NÃO foram impactados pelas campanhas selecionadas. Execute a query abaixo:

```sql
SELECT * FROM postgraphql.get_facebook_activists_by_campaigns_both_inclusion_exclusion(
    '{ "message": "20171114124214" }',
    ARRAY[ID_CAMPANHA_X, ID_CAMPANHA_Y],
    ARRAY[ID_CAMPANHA_W]
);
```
- O resultado esperado neste caso é: **18**

## `get_facebook_activists_strategy`
O papel desta function é abstrair a lógica de verificação de qual função deve ser chamada para segmentar os ativistas... Códigos que controlam essa lógica [como este aqui do bonde-client](https://github.com/nossas/bonde-client/blob/develop/routes/admin/authenticated/external/bot/components/activist-segmentation-form.js#L52-L103) por exemplo, deixariam de existir...

- Segmentação por: **Apenas Exclusão de Campanha**
```sql
SELECT *
FROM postgraphql.get_facebook_bot_activists_strategy(
    '{ "message": "20171114124214", "campaignExclusionIds": "{ID_CAMPANHA_X, ID_CAMPANHA_Y}" }'
);
```
Deve retornar os mesmos valores que:
```sql
SELECT * FROM postgraphql.get_facebook_activists_by_campaigns_exclusion(
    '{ "message": "20171114124214" }',
    ARRAY[ID_CAMPANHA_X, ID_CAMPANHA_Y]
);
```

- Segmentação por: **Apenas União de Campanha**
```sql
SELECT *
FROM postgraphql.get_facebook_bot_activists_strategy(
    '{ "message": "20171114124214", "campaignInclusionIds": "{ID_CAMPANHA_X, ID_CAMPANHA_Y}" }'
);
```
Deve retornar os mesmos valores que:
```sql
SELECT * FROM postgraphql.get_facebook_activists_by_campaigns_inclusion(
    '{ "message": "20171114124214" }',
    ARRAY[ID_CAMPANHA_X, ID_CAMPANHA_Y]
);
```

- Segmentação por: **União e Exclusão de Campanha**
```sql
SELECT *
FROM postgraphql.get_facebook_bot_activists_strategy(
    '{ "message": "20171114124214", "campaignExclusionIds": "{ID_CAMPANHA_X, ID_CAMPANHA_Y}", "campaignInclusionIds": "{ID_CAMPANHA_W}" }'
);
```
Deve retornar os mesmos valores que:
```sql
SELECT * FROM postgraphql.get_facebook_activists_by_campaigns_both_inclusion_exclusion(
    '{ "message": "20171114124214" }',
    ARRAY[ID_CAMPANHA_X, ID_CAMPANHA_Y],
    ARRAY[ID_CAMPANHA_W]
);
```

- Segmentação por: **Apenas Mensagem**
```sql
SELECT * FROM postgraphql.get_facebook_bot_activists_strategy('{ "message": "oi beta" }');
```
Deve retornar os mesmos valores que:
```sql
SELECT * FROM postgraphql.get_facebook_activists_by_message('oi beta');
```

- Segmentação por: **Apenas Quick Reply**
```sql
SELECT * FROM postgraphql.get_facebook_bot_activists_strategy('{ "quickReply": "QUICK_REPLY_G" }');
```
Deve retornar os mesmos valores que:
```sql
SELECT * FROM postgraphql.get_facebook_activists_by_quick_reply('QUICK_REPLY_G');
```

- Segmentação por: **Apenas Intervalo de Data**
```sql
SELECT * FROM postgraphql.get_facebook_bot_activists_strategy('{ "dateIntervalStart": "2017-09-01", "dateIntervalEnd": "2017-09-02" }');
```
Deve retornar os mesmos valores que:
```sql
SELECT * FROM postgraphql.get_facebook_activists_by_date_interval('2017-09-01', '2017-09-02');
```

- Segmentação por: **Quick Reply e Intervalo de Data**
```sql
SELECT * FROM postgraphql.get_facebook_bot_activists_strategy('{ "quickReply": "QUICK_REPLY_G", "dateIntervalStart": "2017-09-01", "dateIntervalEnd": "2017-09-02" }');
```
Deve retornar os mesmos valores que:
```sql
SELECT * FROM postgraphql.get_facebook_activists_by_quick_reply_date_interval('QUICK_REPLY_G', '2017-09-01', '2017-09-02');
```

- Segmentação por: **Mensagem e Intervalo de Data**
```sql
SELECT * FROM postgraphql.get_facebook_bot_activists_strategy('{ "message": "oi beta", "dateIntervalStart": "2017-09-01", "dateIntervalEnd": "2017-09-02" }');
```
Deve retornar os mesmos valores que:
```sql
SELECT * FROM postgraphql.get_facebook_activists_by_message_date_interval('oi beta', '2017-09-01', '2017-09-02');
```

- Segmentação por: **Mensagem e Quick Reply**
```sql
SELECT * FROM postgraphql.get_facebook_bot_activists_strategy('{ "message": "oi beta", "quickReply": "QUICK_REPLY_G" }');
```
Deve retornar os mesmos valores que:
```sql
SELECT * FROM postgraphql.get_facebook_activists_by_message_quick_reply('oi beta', 'QUICK_REPLY_G');
```

- Segmentação por: **Mensagem, Quick Reply e Intervalo de Data**
```sql
SELECT * FROM postgraphql.get_facebook_bot_activists_strategy('{ "message": "oi beta", "quickReply": "QUICK_REPLY_G", "dateIntervalStart": "2017-09-01", "dateIntervalEnd": "2017-09-02" }');
```
Deve retornar os mesmos valores que:
```sql
SELECT * FROM postgraphql.get_facebook_activists_by_message_quick_reply_date_interval('oi beta', 'QUICK_REPLY_G', '2017-09-01', '2017-09-02');
```

## `get_facebook_bot_campaign_activists_by_campaign_id`
O papel desta function é retornar a lista de ativistas de determinada campanha.
Utilize as opções abaixo para testar a function:

**SQL**
```sql
SELECT * FROM postgraphql.get_facebook_bot_campaign_activists_by_campaign_id(
    (SELECT MAX(id) FROM public.facebook_bot_campaigns)
);
```

**GraphQL**
```graphql
query fetchFacebookBotCampaignActivistsByCampaignId($campaignId: Int!) {
  query: getFacebookBotCampaignActivistsByCampaignId(campaignId: $campaignId) {
    totalCount
    activists: nodes {
      id
      facebookBotCampaignId
      facebookBotActivistId
      fbContextRecipientId
      received
      log
    }
  }
}
```
**Query Variables**
```json
{
  "campaignId": 80
}
```
- O resultado esperado é a lista de ativistas da última campanha registrada.

## `update_facebook_bot_campaign_activists`
O papel desta function é atualizar o registro do ativistas impactado por uma determinada campanha.
Utilize as opções abaixo para testar a function:

**SQL**
```sql
SELECT * FROM postgraphql.update_facebook_bot_campaign_activists(
    (SELECT MAX(id) FROM public.facebook_bot_campaign_activists),
    NOT (SELECT received FROM public.facebook_bot_campaign_activists ORDER BY id DESC LIMIT 1),
    '{ "err": "Recipient not found" }'
);
```

**GraphQL**
```graphql
mutation updateFacebookBotCampaignActivists(
  $facebookBotCampaignActivistId: Int!
  $received: Boolean!
  $log: Json!
) {
  updateFacebookBotCampaignActivists(input: {
    facebookBotCampaignActivistId: $facebookBotCampaignActivistId,
    ctxReceived: $received,
    ctxLog: $log
  }) {
    facebookBotCampaignActivists {
      id
      facebookBotCampaignId
      facebookBotActivistId
      received
      log
      createdAt
      updatedAt
    }
  }
}
```
**Query Variables**
```json
{
  "facebookBotCampaignActivistId": 186,
  "received": true,
  "log": "{ \"err\": \"Recipient not found\" }"
}
```
- O resultado esperado é que os dados do último registro de ativista impactado por uma certa campanha tenham sido atualizados...
