### PR TITLE
Feature/add score to user mobilizations

### DIFF
--- a/db/migrate/20180625145413_adds_score_to_user_mobilizations.rb
+++ b/db/migrate/20180625145413_adds_score_to_user_mobilizations.rb
@@ -1,0 +1,20 @@
+class AddsScoreToUserMobilizations < ActiveRecord::Migration
+  def up
+    execute %Q{
+CREATE OR REPLACE FUNCTION postgraphql.user_mobilizations_score (m postgraphql.user_mobilizations)
+returns BIGINT as $$
+    select count(1)
+    from public.activist_actions aa
+        where aa.mobilization_id  = m.id
+$$ language sql stable;
+
+GRANT EXECUTE ON function postgraphql.user_mobilizations_score(m postgraphql.user_mobilizations) to common_user, admin;
+}
+  end
+
+  def down
+    execute %Q{
+drop function postgraphql.user_mobilizations_score(m postgraphql.user_mobilizations);
+}
+  end
+end

--- a/db/migrate/20180625150342_adjust_score_user_mobilizations_to_returns_int.rb
+++ b/db/migrate/20180625150342_adjust_score_user_mobilizations_to_returns_int.rb
@@ -1,0 +1,22 @@
+class AdjustScoreUserMobilizationsToReturnsInt < ActiveRecord::Migration
+  def up
+    execute %Q{
+drop function IF EXISTS postgraphql.user_mobilizations_score(m postgraphql.user_mobilizations);
+
+CREATE OR REPLACE FUNCTION postgraphql.user_mobilizations_score (m postgraphql.user_mobilizations)
+returns integer as $$
+    select count(1)::INT
+    from public.activist_actions aa
+        where aa.mobilization_id  = m.id
+$$ language sql stable;
+
+GRANT EXECUTE ON function postgraphql.user_mobilizations_score(m postgraphql.user_mobilizations) to common_user, admin;
+}
+  end
+
+  def down
+    execute %Q{
+drop function postgraphql.user_mobilizations_score(m postgraphql.user_mobilizations);
+}
+  end
+end


### PR DESCRIPTION
> Adicionado columa score na view user_mobilizations
- Exemplo de uso
```
query {
  allUserMobilizations{
    nodes{
      name
      slug
      customDomain
      score
    }
  }
}
```
- Exemplo de retorno
```
{
    "data": {
	"allUserMobilizations": {
	    "nodes": [
		{
		    "name": "Hudson",
		    "slug": "hudson",
		    "customDomain": null,
		    "score": 7
		}
	    ]
	}
    }
}
```
> Permissão de execução para `common_user`, `admin`
