### PR TITLE
updated vulnerabilities from gem sprockets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,7 +383,7 @@ GEM
     slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)


### PR DESCRIPTION
Update gem sprockets to fix vulnerabilities

References: https://blog.heroku.com/rails-asset-pipeline-vulnerability