### PR TITLE
rollback of create dns in route53 async to inside rails again

### DIFF
--- a/app/models/dns_hosted_zone.rb
+++ b/app/models/dns_hosted_zone.rb
@@ -3,13 +3,13 @@ require 'net/dns'
 class DnsHostedZone < ActiveRecord::Base
   belongs_to :community
 
-  # after_create :create_hosted_zone_on_aws, unless: :ignore_syncronization?
-  # after_create :create_default_records_on_aws, unless: :ignore_syncronization?
-  # after_create :load_record_from_aws, unless: :ignore_syncronization?
+  after_create :create_hosted_zone_on_aws, unless: :ignore_syncronization?
+  after_create :create_default_records_on_aws, unless: :ignore_syncronization?
+  after_create :load_record_from_aws, unless: :ignore_syncronization?
 
   # run postgres function
   # This function create a new hosted_zone and default dns_records in route53 (aws-sdk) and updated local database
-  after_create :create_completed_hosted_zone
+  # after_create :create_completed_hosted_zone
 
   before_destroy :delete_hosted_zone
 

--- a/spec/models/dns_hosted_zone_spec.rb
+++ b/spec/models/dns_hosted_zone_spec.rb
@@ -81,12 +81,4 @@ RSpec.describe DnsHostedZone, type: :model do
       end
     end
   end
-
-  describe 'POST /communities/:community_id/dns_hosted_zones/' do
-    let(:resource)  { build(:dns_hosted_zone) }
-    before do
-      expect(resource).to receive(:create_completed_hosted_zone).and_call_original
-    end
-    it { resource.save }
-  end
 end


### PR DESCRIPTION
Realizei um teste em staging e funcionou conforme esperado. 
@igr-santos acredito que agora vc consiga reproduzir o erro da forma correta.

![screen shot 2018-07-11 at 20 07 38](https://user-images.githubusercontent.com/6902011/42603899-3ae1984a-8546-11e8-9877-d55f4632290a.png)
