### PR TITLE
Forgot Password

### DIFF
--- a/db/migrate/20180711234242_adjust_function_request_reset_password_token.rb
+++ b/db/migrate/20180711234242_adjust_function_request_reset_password_token.rb
@@ -76,7 +76,7 @@ comment on function postgraphql.request_reset_password_token(email text, locale 
 
 grant execute on function postgraphql.request_reset_password_token(email text, locale text) to anonymous, postgraphql;
 grant usage on schema pgjwt to postgraphql, anonymous;
-grant execute on function public.configuration to postgraphql, anonymous;
+grant execute on function public.configuration(text) to postgraphql, anonymous;
 grant select on public.configurations to postgraphql, anonymous;
 
 }

--- a/db/migrate/20180711234242_adjust_function_request_reset_password_token.rb
+++ b/db/migrate/20180711234242_adjust_function_request_reset_password_token.rb
@@ -1,0 +1,141 @@
+class AdjustFunctionRequestResetPasswordToken < ActiveRecord::Migration
+  def up
+    execute %Q{
+drop function if EXISTS postgraphql.request_reset_password_token(data json);
+
+CREATE OR REPLACE FUNCTION postgraphql.request_reset_password_token(email text, locale text default 'pt-BR')
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$
+    declare
+        _user public.users;
+        _notification_template_id integer;
+        _locale text;
+        _notification public.notifications;
+    begin
+        _locale := coalesce(locale, 'pt-BR');
+
+        -- find user by email
+        select * from public.users u where u.email = $1
+            into _user;
+
+        if _user.id is null then
+            raise 'user_not_found';
+        end if;
+
+        -- generate new reset token
+        update public.users
+            set reset_password_token = pgjwt.sign(json_build_object(
+              'id', _user.id,
+              'expirated_at', now() + interval '48 hours'
+          ), public.configuration('jwt_secret'), 'HS512')
+            where id = _user.id;
+
+        -- TODO think other utilities this snippet
+        -- get notification template id for user locale
+        select nt.id from public.notification_templates nt where label = 'reset_password_instructions'
+            and nt.locale = _locale limit 1
+            into _notification_template_id;
+
+        -- fallback on default locale when locale from user not found
+        if _notification_template_id is null then
+            select nt.id from public.notification_templates nt where label = 'reset_password_instructions'
+                and nt.locale = 'pt-BR'
+                into _notification_template_id;
+
+            if _notification_template_id is null then
+                raise 'invalid_notification_template';
+            end if;
+        end if;
+
+        -- notify user about reset password instructions
+        insert into public.notifications(user_id, notification_template_id, template_vars, created_at, updated_at)
+            values (_user.id, _notification_template_id, json_build_object(
+                'user', json_build_object(
+                    'id', _user.id,
+                    'uid', _user.uid,
+                    'email', _user.email,
+                    'first_name', _user.first_name,
+                    'last_name', _user.last_name,
+                    'reset_password_token', _user.reset_password_token)
+            ), now(), now()) returning * into _notification;
+
+        -- notify to notification_channels
+        perform pg_notify('notifications_channel',pgjwt.sign(json_build_object(
+            'action', 'deliver_notification',
+            'id', _notification.id,
+            'created_at', now(),
+            'sent_to_queuing', now(),
+            'jit', now()::timestamp
+        ), public.configuration('jwt_secret'), 'HS512'));
+    end;
+$function$;
+
+comment on function postgraphql.request_reset_password_token(email text, locale text) is 
+  E'@email text\n@locale text\nCreate token to user reset password and send notification about this.';
+
+grant execute on function postgraphql.request_reset_password_token(email text, locale text) to anonymous, postgraphql;
+grant usage on schema pgjwt to postgraphql, anonymous;
+grant execute on function public.configuration to postgraphql, anonymous;
+grant select on public.configurations to postgraphql, anonymous;
+
+}
+  end
+
+  def down
+    execute %Q{
+CREATE OR REPLACE FUNCTION postgraphql.request_reset_password_token(data json)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$
+    declare
+        _user public.users;
+        _notification_template_id integer;
+        _locale text;
+    begin
+        _locale := coalesce($1->>'locale'::text, 'pt-BR');
+
+        -- find user by email
+        select * from users u where u.email = ($1->>'email'::text)::email
+            into _user;
+
+        if _user.id is null then
+            raise 'user_not_found';
+        end if;
+
+        -- generate new reset token
+        update public.users
+            set reset_password_token = uuid_generate_v4()
+            where id = _user.id;
+
+        -- get notification template id for user locale
+        select id from public.notification_templates where label = 'reset_password_instructions'
+            and locale = _locale limit 1
+            into _notification_template_id;
+
+        -- fallback on default locale when locale from user not found
+        if _notification_template_id is null then
+            select id from public.notification_templates where label = 'reset_password_instructions'
+                and locale = 'pt-BR'
+                into _notification_template_id;
+
+            if _notification_template_id is null then
+                raise 'invalid_template';
+            end if;
+        end if;
+        -- notify user about reset password instructions
+        insert into public.notifications(user_id, notification_template_id, template_vars, created_at, updated_at)
+            values (_user.id, _notification_template_id, json_build_object(
+                'user', json_build_object(
+                    'id', _user.id,
+                    'uid', _user.uid,
+                    'email', _user.email,
+                    'first_name', _user.first_name,
+                    'last_name', _user.last_name,
+                    'reset_password_token', _user.reset_password_token)
+            ), now(), now());
+    end;
+$function$
+}
+  end
+end

--- a/db/migrate/20180719193340_change_function_name_request_reset_password_token.rb
+++ b/db/migrate/20180719193340_change_function_name_request_reset_password_token.rb
@@ -1,0 +1,163 @@
+class ChangeFunctionNameRequestResetPasswordToken < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      drop function if exists postgraphql.request_reset_password_token(email text, locale text);
+
+      CREATE OR REPLACE FUNCTION postgraphql.reset_password_token_request(email text, locale text DEFAULT 'pt-BR'::text)
+       RETURNS void
+       LANGUAGE plpgsql
+      AS $function$
+          declare
+              _user public.users;
+              _notification_template_id integer;
+              _locale text;
+              _notification public.notifications;
+          begin
+              _locale := coalesce(locale, 'pt-BR');
+
+              -- find user by email
+              select * from public.users u where u.email = $1
+                  into _user;
+
+              if _user.id is null then
+                  raise 'user_not_found';
+              end if;
+
+              -- generate new reset token
+              update public.users
+                  set reset_password_token = pgjwt.sign(json_build_object(
+                    'id', _user.id,
+                    'expirated_at', now() + interval '48 hours'
+                ), public.configuration('jwt_secret'), 'HS512')
+                  where id = _user.id
+              returning * into _user;
+
+              -- TODO think other utilities this snippet
+              -- get notification template id for user locale
+              select nt.id from public.notification_templates nt where label = 'reset_password_instructions'
+                  and nt.locale = _locale limit 1
+                  into _notification_template_id;
+
+              -- fallback on default locale when locale from user not found
+              if _notification_template_id is null then
+                  select nt.id from public.notification_templates nt where label = 'reset_password_instructions'
+                      and nt.locale = 'pt-BR'
+                      into _notification_template_id;
+
+                  if _notification_template_id is null then
+                      raise 'invalid_notification_template';
+                  end if;
+              end if;
+
+              -- notify user about reset password instructions
+              insert into public.notifications(user_id, notification_template_id, template_vars, created_at, updated_at)
+                  values (_user.id, _notification_template_id, json_build_object(
+                      'user', json_build_object(
+                          'id', _user.id,
+                          'uid', _user.uid,
+                          'email', _user.email,
+                          'first_name', _user.first_name,
+                          'last_name', _user.last_name,
+                          'reset_password_token', _user.reset_password_token)
+                  ), now(), now()) returning * into _notification;
+
+              -- notify to notification_channels
+              perform pg_notify('notifications_channel',pgjwt.sign(json_build_object(
+                  'action', 'deliver_notification',
+                  'id', _notification.id,
+                  'created_at', now(),
+                  'sent_to_queuing', now(),
+                  'jit', now()::timestamp
+              ), public.configuration('jwt_secret'), 'HS512'));
+          end;
+      $function$;
+
+      comment on function postgraphql.reset_password_token_request(email text, locale text) is
+        E'@email text\n@locale text\nCreate token to user reset password and send notification about this.';
+
+      grant execute on function postgraphql.reset_password_token_request(email text, locale text) to anonymous, postgraphql;
+      grant usage on schema pgjwt to postgraphql, anonymous;
+      grant execute on function public.configuration(text) to postgraphql, anonymous;
+      grant select on public.configurations to postgraphql, anonymous;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      CREATE OR REPLACE FUNCTION postgraphql.request_reset_password_token(email text, locale text DEFAULT 'pt-BR'::text)
+       RETURNS void
+       LANGUAGE plpgsql
+      AS $function$
+          declare
+              _user public.users;
+              _notification_template_id integer;
+              _locale text;
+              _notification public.notifications;
+          begin
+              _locale := coalesce(locale, 'pt-BR');
+
+              -- find user by email
+              select * from public.users u where u.email = $1
+                  into _user;
+
+              if _user.id is null then
+                  raise 'user_not_found';
+              end if;
+
+              -- generate new reset token
+              update public.users
+                  set reset_password_token = pgjwt.sign(json_build_object(
+                    'id', _user.id,
+                    'expirated_at', now() + interval '48 hours'
+                ), public.configuration('jwt_secret'), 'HS512')
+                  where id = _user.id
+              returning * into _user;
+
+              -- TODO think other utilities this snippet
+              -- get notification template id for user locale
+              select nt.id from public.notification_templates nt where label = 'reset_password_instructions'
+                  and nt.locale = _locale limit 1
+                  into _notification_template_id;
+
+              -- fallback on default locale when locale from user not found
+              if _notification_template_id is null then
+                  select nt.id from public.notification_templates nt where label = 'reset_password_instructions'
+                      and nt.locale = 'pt-BR'
+                      into _notification_template_id;
+
+                  if _notification_template_id is null then
+                      raise 'invalid_notification_template';
+                  end if;
+              end if;
+
+              -- notify user about reset password instructions
+              insert into public.notifications(user_id, notification_template_id, template_vars, created_at, updated_at)
+                  values (_user.id, _notification_template_id, json_build_object(
+                      'user', json_build_object(
+                          'id', _user.id,
+                          'uid', _user.uid,
+                          'email', _user.email,
+                          'first_name', _user.first_name,
+                          'last_name', _user.last_name,
+                          'reset_password_token', _user.reset_password_token)
+                  ), now(), now()) returning * into _notification;
+
+              -- notify to notification_channels
+              perform pg_notify('notifications_channel',pgjwt.sign(json_build_object(
+                  'action', 'deliver_notification',
+                  'id', _notification.id,
+                  'created_at', now(),
+                  'sent_to_queuing', now(),
+                  'jit', now()::timestamp
+              ), public.configuration('jwt_secret'), 'HS512'));
+          end;
+      $function$
+
+
+      grant execute on function postgraphql.reset_password_token_request(email text, locale text) to anonymous, postgraphql;
+      grant usage on schema pgjwt to postgraphql, anonymous;
+      grant execute on function public.configuration to postgraphql, anonymous;
+      grant select on public.configurations to postgraphql, anonymous;
+    SQL
+  end
+end

--- a/spec/sql-specs/postgraphql/function.request_reset_password_token_test.sql
+++ b/spec/sql-specs/postgraphql/function.request_reset_password_token_test.sql
@@ -5,13 +5,17 @@ begin;
         ('reset_password_instructions', 'reset password subject', 'reset password body', now(), now(), 'es');
 
     -- insert test user
-    insert into public.users(id, email, provider, uid, encrypted_password, admin, locale) values 
+    insert into public.users(id, email, provider, uid, encrypted_password, admin, locale) values
         (1, 'foo@foo.com', 'bonde', '1', crypt('123456', gen_salt('bf', 9)), false, 'pt-BR');
+
+    -- insert basic jwt_secret
+    insert into public.configurations(name, value, created_at, updated_at)
+    values('jwt_secret', '1234567899', now(), now());
 
   select plan(8);
 
-  select has_function('postgraphql', 'request_reset_password_token', ARRAY['json']);
-  select function_returns('postgraphql', 'request_reset_password_token', ARRAY['json'], 'void');
+  select has_function('postgraphql', 'request_reset_password_token', ARRAY['text', 'text']);
+  select function_returns('postgraphql', 'request_reset_password_token', ARRAY['text', 'text'], 'void');
 
   create or replace function test_request_reset_password_token()
   returns setof text language plpgsql as $$
@@ -21,7 +25,7 @@ begin;
 
     set local role anonymous;
 
-    perform postgraphql.request_reset_password_token(json_build_object('email', 'foo@foo.com', 'locale', 'pt-BR'));
+    perform postgraphql.request_reset_password_token('foo@foo.com');
     select * from users where id = 1
     into _user;
 
@@ -41,7 +45,7 @@ begin;
     );
 
 
-    perform postgraphql.request_reset_password_token(json_build_object('email', 'foo@foo.com', 'locale', 'es'));
+    perform postgraphql.request_reset_password_token('foo@foo.com', 'es');
 
     -- should generate a new password reset token
     return next ok((_user.reset_password_token is not null), 'should generate a reset password token');
@@ -59,7 +63,7 @@ begin;
     );
 
 
-    perform postgraphql.request_reset_password_token(json_build_object('email', 'foo@foo.com', 'locale', 'en'));
+    perform postgraphql.request_reset_password_token('foo@foo.com', 'en');
 
     -- should generate a new password reset token
     return next ok((_user.reset_password_token is not null), 'should generate a reset password token');

--- a/spec/sql-specs/postgraphql/function.reset_password_token_request_test.sql
+++ b/spec/sql-specs/postgraphql/function.reset_password_token_request_test.sql
@@ -14,10 +14,10 @@ begin;
 
   select plan(8);
 
-  select has_function('postgraphql', 'request_reset_password_token', ARRAY['text', 'text']);
-  select function_returns('postgraphql', 'request_reset_password_token', ARRAY['text', 'text'], 'void');
+  select has_function('postgraphql', 'reset_password_token_request', ARRAY['text', 'text']);
+  select function_returns('postgraphql', 'reset_password_token_request', ARRAY['text', 'text'], 'void');
 
-  create or replace function test_request_reset_password_token()
+  create or replace function test_reset_password_token_request()
   returns setof text language plpgsql as $$
   declare
     _user public.users;
@@ -25,7 +25,7 @@ begin;
 
     set local role anonymous;
 
-    perform postgraphql.request_reset_password_token('foo@foo.com');
+    perform postgraphql.reset_password_token_request('foo@foo.com');
     select * from users where id = 1
     into _user;
 
@@ -45,7 +45,7 @@ begin;
     );
 
 
-    perform postgraphql.request_reset_password_token('foo@foo.com', 'es');
+    perform postgraphql.reset_password_token_request('foo@foo.com', 'es');
 
     -- should generate a new password reset token
     return next ok((_user.reset_password_token is not null), 'should generate a reset password token');
@@ -63,7 +63,7 @@ begin;
     );
 
 
-    perform postgraphql.request_reset_password_token('foo@foo.com', 'en');
+    perform postgraphql.reset_password_token_request('foo@foo.com', 'en');
 
     -- should generate a new password reset token
     return next ok((_user.reset_password_token is not null), 'should generate a reset password token');
@@ -85,6 +85,5 @@ begin;
 
   end;
   $$;
-  select * from test_request_reset_password_token();
-
+  select * from test_reset_password_token_request();
 rollback;


### PR DESCRIPTION
Foi ajustada a função `request_reset_password_token` 
- para receber os parâmetros diretamente na assinatura
- token criado a com um payload contento tempo de expiração e id do user
- `pg_notify` para disparar as notificações ao user