### PR TITLE
Fix create template_mobilizations

### DIFF
--- a/app/models/mobilization.rb
+++ b/app/models/mobilization.rb
@@ -44,7 +44,6 @@ class Mobilization < ActiveRecord::Base
     self.header_font = template.header_font
     self.body_font = template.body_font
     self.facebook_share_image = template.facebook_share_image
-    self.custom_domain = template.custom_domain
     self.twitter_share_text = template.twitter_share_text
     self
   end

--- a/app/models/template_widget.rb
+++ b/app/models/template_widget.rb
@@ -1,6 +1,5 @@
 class TemplateWidget < ActiveRecord::Base
   validates :sm_size, :md_size, :lg_size, :kind, presence: true
-  validates :mailchimp_segment_id, uniqueness: true, allow_nil: true
   belongs_to :template_block
   has_one :mobilization, through: :template_block
   store_accessor :settings
@@ -15,7 +14,6 @@ class TemplateWidget < ActiveRecord::Base
   	template.sm_size = widget.sm_size
   	template.md_size = widget.md_size
   	template.lg_size = widget.lg_size
-  	template.mailchimp_segment_id = widget.mailchimp_segment_id
   	template.action_community = widget.action_community
   	template.exported_at = widget.exported_at
   	template

--- a/spec/models/mobilization_spec.rb
+++ b/spec/models/mobilization_spec.rb
@@ -110,8 +110,8 @@ RSpec.describe Mobilization, type: :model do
       expect(subject.facebook_share_image).to eq(@template.facebook_share_image)
     end
 
-    it "should copy the custom_domain value" do
-      expect(subject.custom_domain).to eq(@template.custom_domain)
+    it "should not copy the custom_domain value" do
+      expect(subject.custom_domain).to_not eq(@template.custom_domain)
     end
 
     it "should copy the twitter_share_text value" do

--- a/spec/models/template_widget_spec.rb
+++ b/spec/models/template_widget_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe TemplateWidget, type: :model do
 	it { should validate_presence_of :md_size }
 	it { should validate_presence_of :lg_size }
 	it { should validate_presence_of :kind }
-	it { should validate_uniqueness_of :mailchimp_segment_id }
 
 	describe "create_from" do
 		context "create an instance from Widget" do
@@ -40,15 +39,11 @@ RSpec.describe TemplateWidget, type: :model do
 				expect(@templateWidget.lg_size).to eq(@widget.lg_size)
 			end
 
-			it "should have same mailchimp_segment_id value" do 
-				expect(@templateWidget.mailchimp_segment_id).to eq(@widget.mailchimp_segment_id)
-			end
-
 			it "should have same action_community value" do 
 				expect(@templateWidget.action_community).to eq(@widget.action_community)
 			end
 
-			it "should have same exported_at value" do 
+			it "should have same exported_at value" do
 				expect(@templateWidget.exported_at).to eq(@widget.exported_at)
 			end
 		end


### PR DESCRIPTION
Corrigido a forma de criar templates para não salvar o `mailchimp_segment_id` nas widgets copiadas. 
Atualmente este campo estava com uma validação de não poder se repetir. Causando assim problemas ao tentar gerar mais de um template da mesma mobilização.
A partir de agora não iremos mais copiar esse campo para o template.