### PR TITLE
Hotfix/templates

### DIFF
--- a/app/controllers/blocks_controller.rb
+++ b/app/controllers/blocks_controller.rb
@@ -6,7 +6,7 @@ class BlocksController < ApplicationController
   def index
     mobilization = policy_scope(Mobilization).filter(params.slice(:custom_domain, :slug))
     mobilization = mobilization.first if mobilization.kind_of?(Array)
-    blocks = mobilization.present? ? mobilization.blocks.not_deleted.order(:position) : []
+    blocks = mobilization.present? ? mobilization.blocks.order(:position) : []
     render json: blocks
   end
 end

--- a/app/controllers/mobilizations/blocks_controller.rb
+++ b/app/controllers/mobilizations/blocks_controller.rb
@@ -4,7 +4,7 @@ class Mobilizations::BlocksController < ApplicationController
   after_action :verify_policy_scoped, only: %i[index]
 
   def index
-    render json: policy_scope(Block).not_deleted.where(mobilization_id: params[:mobilization_id]).order(:position)
+    render json: policy_scope(Block).where(mobilization_id: params[:mobilization_id]).order(:position)
   end
 
   def create
@@ -18,7 +18,7 @@ class Mobilizations::BlocksController < ApplicationController
   end
 
   def update
-    @block = Block.not_deleted.where(mobilization_id: params[:mobilization_id], id: params[:id]).first
+    @block = Block.find(params[:id])
     authorize @block
     @block.update!(block_params)
     render json: @block
@@ -28,7 +28,7 @@ class Mobilizations::BlocksController < ApplicationController
     @block = Block.find(params[:blocks].first[:id])
     authorize @block
 
-    if params[:blocks].count >= 2
+    if params[:blocks].count >= 1
       batch = Block.update_blocks(blocks_params[:blocks])
 
       if batch[:status] == 'success'
@@ -37,7 +37,7 @@ class Mobilizations::BlocksController < ApplicationController
         render json: { errors: batch.to_json }, status: :unprocessable_entity
       end
     else
-      render json: { errors: 'must have two or more blocks in list' }, status: :unprocessable_entity
+      render json: { errors: 'must have one or more blocks in list' }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/mobilizations/widgets_controller.rb
+++ b/app/controllers/mobilizations/widgets_controller.rb
@@ -6,7 +6,6 @@ class Mobilizations::WidgetsController < ApplicationController
   def index
     @widgets = policy_scope(Widget).
       joins(:block).
-      not_deleted.
       where({
       blocks: {
         deleted_at: nil,
@@ -17,7 +16,7 @@ class Mobilizations::WidgetsController < ApplicationController
   end
 
   def update
-    @widget = Widget.not_deleted.find(params[:id])
+    @widget = Widget.find(params[:id])
     authorize @widget
 
     if @widget.update!(widget_params)

--- a/app/controllers/mobilizations_controller.rb
+++ b/app/controllers/mobilizations_controller.rb
@@ -55,18 +55,18 @@ class MobilizationsController < ApplicationController
     template_mobilization_id = params[:mobilization][:template_mobilization_id]
     if not @mobilization
       return404
-    elsif template_mobilization_id
+    elsif template_mobilization_id and !@mobilization.blocks.present?
       template = TemplateMobilization.find_by({id: template_mobilization_id})
       if template
         authorize @mobilization
         @mobilization.copy_from template
-        Mobilization.transaction do 
+        Mobilization.transaction do
           @mobilization.save
 
-          template.template_blocks.order(:id).each do |template_block|
+          template.template_blocks.each do |template_block|
             block = Block.create_from template_block, @mobilization
             block.save!
-            template_block.template_widgets.order(:id).each do |template_widget|
+            template_block.template_widgets.each do |template_widget|
               widget = Widget.create_from template_widget, block
               widget.save!
             end

--- a/app/controllers/template_mobilizations_controller.rb
+++ b/app/controllers/template_mobilizations_controller.rb
@@ -77,7 +77,7 @@ class TemplateMobilizationsController < ApplicationController
 				template_block = TemplateBlock.create_from block, template_mobilization
 				template_mobilization.save!
 
-				block.widgets.each do |widget|
+				block.widgets.order(:id).each do |widget|
 					template_widget = TemplateWidget.create_from widget, template_block
 					template_widget.save!
 				end

--- a/app/controllers/template_mobilizations_controller.rb
+++ b/app/controllers/template_mobilizations_controller.rb
@@ -73,11 +73,11 @@ class TemplateMobilizationsController < ApplicationController
 		TemplateMobilization.transaction do
 			template_mobilization.save!
 
-			mobilization.blocks.order(:id).each do |block|
+			mobilization.blocks.each do |block|
 				template_block = TemplateBlock.create_from block, template_mobilization
 				template_mobilization.save!
 
-				block.widgets.order(:id).each do |widget|
+				block.widgets.each do |widget|
 					template_widget = TemplateWidget.create_from widget, template_block
 					template_widget.save!
 				end

--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -5,9 +5,9 @@ class WidgetsController < ApplicationController
 
   # FIXME efficiency
   def index
-    mobilization = policy_scope(Mobilization).not_deleted.filter(params.slice(:custom_domain, :slug))
+    mobilization = policy_scope(Mobilization).filter(params.slice(:custom_domain, :slug))
     mobilization = mobilization.first if mobilization.kind_of?(Array)
-    widgets = mobilization.present? ? mobilization.widgets.not_deleted.order(:id) : Widget.none
+    widgets = mobilization.present? ? mobilization.widgets.order(:id) : Widget.none
     render json: widgets
   end
 

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -3,12 +3,11 @@ class Block < ActiveRecord::Base
   belongs_to :mobilization
   has_many :widgets
   accepts_nested_attributes_for :widgets
+  default_scope -> { where(deleted_at: nil) }
 
   after_save do
     mobilization.touch if mobilization.present?
   end
-
-  scope :not_deleted, -> { where(deleted_at: nil) }
 
   def self.create_from template, mobilization_instance
     block = Block.new

--- a/app/models/template_mobilization.rb
+++ b/app/models/template_mobilization.rb
@@ -2,7 +2,7 @@ class TemplateMobilization < ActiveRecord::Base
   include Shareable
   include Filterable
 
-  validates :name, :user_id, :slug, presence: true
+  validates :name, :user_id, presence: true
   belongs_to :user
   belongs_to :community
 
@@ -10,15 +10,16 @@ class TemplateMobilization < ActiveRecord::Base
   has_many :template_widgets, through: :template_blocks
 
   def self.create_from mobilization
-  	template = TemplateMobilization.new
-  	template.name = mobilization.name
-  	template.color_scheme = mobilization.color_scheme
-  	template.header_font = mobilization.header_font
-  	template.body_font = mobilization.body_font
-  	template.facebook_share_image = mobilization.facebook_share_image
-    #TODO discus about implementation of community context
-  	template.community_id = mobilization.community_id
-  	template
+    template = TemplateMobilization.new
+    template.name = mobilization.name
+    template.color_scheme = mobilization.color_scheme
+    template.header_font = mobilization.header_font
+    template.body_font = mobilization.body_font
+    template.facebook_share_image = mobilization.facebook_share_image
+
+    # TODO: discus about implementation of community context
+    template.community_id = mobilization.community_id
+    template
   end
 
 end

--- a/app/models/template_mobilization.rb
+++ b/app/models/template_mobilization.rb
@@ -13,13 +13,10 @@ class TemplateMobilization < ActiveRecord::Base
   	template = TemplateMobilization.new
   	template.name = mobilization.name
   	template.color_scheme = mobilization.color_scheme
-  	template.facebook_share_title = mobilization.facebook_share_title
-  	template.facebook_share_description = mobilization.facebook_share_description
   	template.header_font = mobilization.header_font
   	template.body_font = mobilization.body_font
   	template.facebook_share_image = mobilization.facebook_share_image
-  	template.slug = mobilization.slug
-  	template.twitter_share_text = mobilization.twitter_share_text
+    #TODO discus about implementation of community context
   	template.community_id = mobilization.community_id
   	template
   end

--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -20,7 +20,7 @@ class Widget < ActiveRecord::Base
 
   delegate :user, to: :mobilization
 
-  scope :not_deleted, -> { where(deleted_at: nil) }
+  default_scope -> { where(deleted_at: nil) }
 
   after_save do
     mobilization.touch if mobilization.present?

--- a/db/migrate/20180809141519_removes_mandatary_slug_in_template_mobilization.rb
+++ b/db/migrate/20180809141519_removes_mandatary_slug_in_template_mobilization.rb
@@ -1,0 +1,13 @@
+class RemovesMandatarySlugInTemplateMobilization < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      alter table public.template_mobilizations alter column slug drop not null;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      alter table public.template_mobilizations alter column slug drop not null;
+    SQL
+  end
+end

--- a/spec/controllers/mobilizations/blocks_controller_spec.rb
+++ b/spec/controllers/mobilizations/blocks_controller_spec.rb
@@ -98,9 +98,9 @@ RSpec.describe Mobilizations::BlocksController, type: :controller do
       expect(block2.bg_class).to eq('bg-black')
     end
 
-    it 'should not be update blocks when list for less two' do
+    it 'should be update blocks when list for equals one' do
       put 'batch_update', mobilization_id: mobilization.id, blocks: [{"id": block.id, "position": 2}], format: :json
-      expect(response.status).to eq(422)
+      expect(response.status).to eq(200)
     end
   end
 

--- a/spec/controllers/mobilizations_controller_spec.rb
+++ b/spec/controllers/mobilizations_controller_spec.rb
@@ -88,12 +88,12 @@ RSpec.describe MobilizationsController, type: :controller do
     let(:saved_mobilization) { Mobilization.find mobilization.id }
 
     context "update an existing Mobilization from an existing template" do
-      let(:template_block_1) { TemplateBlock.make! template_mobilization:template }
-      let(:tempalte_widget_1_1) { TemplateWidget.make! template_block:template_block_1 }
-      let(:tempalte_widget_1_2) { TemplateWidget.make! template_block:template_block_1 }
-      let(:template_block_2) { TemplateBlock.make! template_mobilization:template }
-      let(:tempalte_widget_2_1) { TemplateWidget.make! template_block:template_block_2 }
-      let(:tempalte_widget_2_2) { TemplateWidget.make! template_block:template_block_2 }
+      let(:template_block_1) { TemplateBlock.make! template_mobilization: template }
+      let(:tempalte_widget_1_1) { TemplateWidget.make! template_block: template_block_1 }
+      let(:tempalte_widget_1_2) { TemplateWidget.make! template_block: template_block_1 }
+      let(:template_block_2) { TemplateBlock.make! template_mobilization: template }
+      let(:tempalte_widget_2_1) { TemplateWidget.make! template_block: template_block_2 }
+      let(:tempalte_widget_2_2) { TemplateWidget.make! template_block: template_block_2 }
 
       before do
         @template_blocks  = [template_block_1, template_block_2]
@@ -103,7 +103,6 @@ RSpec.describe MobilizationsController, type: :controller do
       end
 
       it { should respond_with 200 }
-
 
       it "should update data from a template" do
         expect(saved_mobilization.header_font).to eq(template.header_font)

--- a/spec/controllers/template_mobilizations_controller_spec.rb
+++ b/spec/controllers/template_mobilizations_controller_spec.rb
@@ -80,15 +80,15 @@ RSpec.describe TemplateMobilizationsController, type: :controller do
     end
   end
 
-  context 'POST #create' do 
+  context 'POST #create' do
     describe 'create a template from existing mobilization' do
       let(:mobilization) { Mobilization.make! user:@user1 }
       let(:block1) { Block.make! mobilization: mobilization }
       let(:block2) { Block.make! mobilization: mobilization }
-      let(:widget1_1) {Widget.make! block:block1}
-      let(:widget2_1) {Widget.make! block:block2}
-      let(:widget2_2) {Widget.make! block:block2}
-      let(:block_sequence) { [] }      
+      let(:widget1_1) {Widget.make! block: block1}
+      let(:widget2_1) {Widget.make! block: block2}
+      let(:widget2_2) {Widget.make! block: block2}
+      let(:block_sequence) { [] }
       let(:widget_sequence) { [] }
 
       before do
@@ -106,32 +106,28 @@ RSpec.describe TemplateMobilizationsController, type: :controller do
       end
 
       it 'should create one TemplateMobilization' do
-        expect(TemplateMobilization.count).to eq(@count_mobilization + 1)        
+        expect(TemplateMobilization.count).to eq(@count_mobilization + 1)
       end
 
       it 'should create two blocks' do
-        expect(TemplateBlock.count).to eq(@count_blocks + 2)        
+        expect(TemplateBlock.count).to eq(@count_blocks + 2)
       end
 
       it 'should create three widgets' do
-        expect(TemplateWidget.count).to eq(@count_widgets + 3)        
+        expect(TemplateWidget.count).to eq(@count_widgets + 3)
       end
 
       it 'should save use the name parameter as template\'s name' do
-        expect(TemplateMobilization.last.name).to eq('Pinky & Brain\'s world conquest')        
+        expect(TemplateMobilization.last.name).to eq('Pinky & Brain\'s world conquest')
       end
 
       it 'should save use the goal parameter as template\'s goal' do
-        expect(TemplateMobilization.last.goal).to eq('World conquest')        
-      end
-
-      it 'should return the template created data' do
-        expect(response.body).to include(mobilization.slug)
+        expect(TemplateMobilization.last.goal).to eq('World conquest')
       end
 
       it 'should create all block nested data' do
         data = JSON.parse response.body
-        expect(TemplateBlock.where("template_mobilization_id = #{data['id']}").count).to eq(2) 
+        expect(TemplateBlock.where("template_mobilization_id = #{data['id']}").count).to eq(2)
       end
 
       it 'should create all nested widget data' do
@@ -147,7 +143,7 @@ RSpec.describe TemplateMobilizationsController, type: :controller do
 
       it 'should save template_widgets on the same order than widgets' do
         widgets = TemplateMobilization.last.
-            template_blocks.order(:id).map{|b| b.template_widgets.order(:id)}.
+          template_blocks.order(:id).map{|b| b.template_widgets.order(:id) }.
             flatten.map{|w| w.settings}
 
 

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -7,15 +7,19 @@ RSpec.describe Block, type: :model do
   it { should validate_presence_of :position }
   it { should accept_nested_attributes_for :widgets }
 
-  describe '.not_deleted' do
+  describe '.default_scope' do
     context 'should not list blocks that has deleted' do
       let!(:block_deleted) { create(:block, deleted_at: DateTime.now)}
+      let!(:block_deleted_2) { create(:block, deleted_at: DateTime.now)}
+      let!(:block_deleted_3) { create(:block, deleted_at: DateTime.now)}
       let!(:block) { create(:block, position: 2) }
 
-      subject { Block.not_deleted }
+      subject { Block.all }
 
       it 'should not include deleted' do
         expect(subject).to_not include(block_deleted)
+        expect(subject).to_not include(block_deleted_2)
+        expect(subject).to_not include(block_deleted_3)
       end
     end
   end

--- a/spec/models/template_mobilization_spec.rb
+++ b/spec/models/template_mobilization_spec.rb
@@ -51,16 +51,8 @@ RSpec.describe TemplateMobilization, type: :model do
 	  		expect(@template.facebook_share_image).to eq(@mobilization.facebook_share_image)
 	  	end
 
-	  	it "should have the same slug as original mobilization" do
-	  		expect(@template.slug).to eq(@mobilization.slug)
-	  	end
-
 	  	it "should have custom_domain to nil" do
 	  		expect(@template.custom_domain).to be_nil
-	  	end
-
-	  	it "should have the same twitter_share_text as original mobilization" do
-	  		expect(@template.twitter_share_text).to eq(@mobilization.twitter_share_text)
 	  	end
 
 	  	it "should have the same community_id as original mobilization" do

--- a/spec/models/widget_spec.rb
+++ b/spec/models/widget_spec.rb
@@ -19,14 +19,26 @@ RSpec.describe Widget, type: :model do
   it { should have_many :matches }
   it { should have_many :activist_pressures }
 
-  describe '.not_deleted' do
-    let!(:deleted) { create(:widget, deleted_at: DateTime.now) }
-    let!(:wiget) { create(:widget, deleted_at: nil) }
+  describe 'default_scope' do
+    let!(:deleted_1) { create(:widget, deleted_at: DateTime.now) }
+    let!(:deleted_2) { create(:widget, deleted_at: DateTime.now) }
+    let!(:deleted_3) { create(:widget, deleted_at: DateTime.now) }
+    let!(:widget_1) { create(:widget, deleted_at: nil) }
+    let!(:widget_2) { create(:widget, deleted_at: nil) }
+    let!(:widget_3) { create(:widget, deleted_at: nil) }
 
-    subject { Widget.not_deleted }
+    subject { Widget.all }
 
     it 'deleted widget should not be returned' do
-      expect(subject).to_not include(deleted)
+      expect(subject).to_not include(deleted_1)
+      expect(subject).to_not include(deleted_2)
+      expect(subject).to_not include(deleted_3)
+    end
+
+    it 'widgets not deleted should be returned' do
+      expect(subject).to include(widget_1)
+      expect(subject).to include(widget_2)
+      expect(subject).to include(widget_3)
     end
   end
 

--- a/spec/sql-specs/public/table.template_mobilizations_test.sql
+++ b/spec/sql-specs/public/table.template_mobilizations_test.sql
@@ -1,12 +1,11 @@
 BEGIN;
-    SELECT plan(6);
+    SELECT plan(5);
 
     -- check table presence
     SELECT has_table('public'::name, 'template_mobilizations'::name);
 
     -- check not nulls
     SELECT col_not_null('public', 'template_mobilizations', 'id', 'should be not null');
-    SELECT col_not_null('public', 'template_mobilizations', 'slug', 'should be not null');
     SELECT col_not_null('public', 'template_mobilizations', 'created_at', 'should be not null');
     SELECT col_not_null('public', 'template_mobilizations', 'updated_at', 'should be not null');
 


### PR DESCRIPTION
> Alterações:

- Removido scope not_deleted de widgets e blocks
- alterado o `default_scope` para que comporte não trazendo os deletados
- `batch_update` alterado regra de receber no mínimo 2 blocos para 1
- adicionado regra na hora de atualizar uma mobilização passando um template para verificar se já existem blocos vinculados a mobi. 
- removido obrigatoriedade do `slug` no template_mobilizations
- retirando mais campos na hora de copiar uma mobi para um template (twitter_share_text, slug, facebook_share_title, facebook_share_description)
