### PR TITLE
[pt-br] Correção ao salvar configurações da widget de doação

### DIFF
--- a/app/controllers/mobilizations/widgets_controller.rb
+++ b/app/controllers/mobilizations/widgets_controller.rb
@@ -20,7 +20,7 @@ class Mobilizations::WidgetsController < ApplicationController
     @widget = Widget.not_deleted.find(params[:id])
     authorize @widget
 
-    if @widget.update!(widget_params)
+    if @widget.update(widget_params)
       render json: @widget
     else
       render json: @widget.errors, status: :unprocessable_entity


### PR DESCRIPTION
## Fix

Ao atualizar uma `widget` o método de update retornava erro `500` caso os parâmetros não fossem válidos. Corrigido para que retorne quais erros acontecem na widget quando da erro.