### PR TITLE
fix: disable send pressure-mail

### DIFF
--- a/app/models/activist_pressure.rb
+++ b/app/models/activist_pressure.rb
@@ -11,7 +11,7 @@ class ActivistPressure < ActiveRecord::Base
   has_one :mobilization, through: :block
   has_one :community, through: :mobilization
 
-  after_commit :async_update_mailchimp, :send_thank_you_email, :send_pressure_email, on: :create, unless: :is_test?
+  after_commit :async_update_mailchimp, :send_thank_you_email, on: :create, unless: :is_test?
   after_commit :add_automatic_tags, on: :create
 
   def as_json(*)
@@ -30,14 +30,6 @@ class ActivistPressure < ActiveRecord::Base
 
   def send_thank_you_email
     ActivistPressureMailer.thank_you_email(self.id).deliver_later
-  end
-
-  def send_pressure_email
-    self.mail[:cc].each do |recipient|
-      mail = self.mail.dup
-      mail[:cc] = recipient
-      ActivistPressureMailer.pressure_email(self.id, mail).deliver_later
-    end
   end
 
   private


### PR DESCRIPTION
- desabilitar envio de e-mail, pois agora o e-mail é enviado atráves do `webhook/activists`