### PR TITLE
fix: change field to order activist_actions

### DIFF
--- a/app/controllers/communities/activist_actions_controller.rb
+++ b/app/controllers/communities/activist_actions_controller.rb
@@ -5,7 +5,7 @@ class Communities::ActivistActionsController < ApplicationController
 
   def index
     authorize community, :can_handle_with_activist_actions?
-    collection = apply_scopes(community.activist_actions.order(action_created_date: :desc))
+    collection = apply_scopes(community.activist_actions.order(action_created_at: :desc))
 
     respond_with do |format|
       format.json do


### PR DESCRIPTION
Após migração de view para tabela, que consta nesse arquivo https://github.com/nossas/bonde-migrations/blob/develop/migrations/2019-11-18-145723_add_table_activist_actions_to_aggregate/up.sql, foi preciso atualizar alguns campos no bonde-server.

Issues
- nossas/bonde-client#1298
